### PR TITLE
feat: allow marking motorcycles and listings as favorites

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,8 @@ import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import Navbar from '@/components/Navbar';
 import Footer from '@/components/Footer';
+import { FavoritesProvider } from '@/hooks/use-favorites';
+import { Toaster } from '@/components/ui/toaster';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -19,11 +21,14 @@ export default function RootLayout({
   return (
     <html lang="fr">
       <body className={inter.className}>
-        <Navbar />
-        <main className="min-h-screen">
-          {children}
-        </main>
-        <Footer />
+        <FavoritesProvider>
+          <Navbar />
+          <main className="min-h-screen">
+            {children}
+          </main>
+          <Footer />
+          <Toaster />
+        </FavoritesProvider>
       </body>
     </html>
   );

--- a/hooks/use-favorites.tsx
+++ b/hooks/use-favorites.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import React, { createContext, useContext, useState } from 'react';
+
+interface FavoritesContextValue {
+  favorites: string[];
+  toggleFavorite: (id: string) => void;
+  isFavorite: (id: string) => boolean;
+}
+
+const FavoritesContext = createContext<FavoritesContextValue | undefined>(undefined);
+
+export const FavoritesProvider = ({ children }: { children: React.ReactNode }) => {
+  const [favorites, setFavorites] = useState<string[]>([]);
+
+  const toggleFavorite = (id: string) => {
+    setFavorites((prev) =>
+      prev.includes(id) ? prev.filter((fav) => fav !== id) : [...prev, id]
+    );
+  };
+
+  const isFavorite = (id: string) => favorites.includes(id);
+
+  return (
+    <FavoritesContext.Provider value={{ favorites, toggleFavorite, isFavorite }}>
+      {children}
+    </FavoritesContext.Provider>
+  );
+};
+
+export const useFavorites = () => {
+  const context = useContext(FavoritesContext);
+  if (!context) {
+    throw new Error('useFavorites must be used within FavoritesProvider');
+  }
+  return context;
+};
+
+export default FavoritesContext;

--- a/src/components/ListingCard.tsx
+++ b/src/components/ListingCard.tsx
@@ -8,6 +8,9 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardFooter } from '@/components/ui/card';
 import { Eye, Heart, MapPin, Calendar, Gauge } from 'lucide-react';
+import { useFavorites } from '@/hooks/use-favorites';
+import { useToast } from '@/hooks/use-toast';
+import { cn } from '@/lib/utils';
 
 interface ListingCardProps {
   listing: {
@@ -27,6 +30,9 @@ interface ListingCardProps {
 }
 
 const ListingCard: React.FC<ListingCardProps> = ({ listing, showActions = true }) => {
+  const { toggleFavorite, isFavorite } = useFavorites();
+  const { toast } = useToast();
+
   const formatPrice = (price: number) => {
     return new Intl.NumberFormat('fr-TN', {
       style: 'currency',
@@ -37,6 +43,14 @@ const ListingCard: React.FC<ListingCardProps> = ({ listing, showActions = true }
 
   const formatMileage = (mileage: number) => {
     return new Intl.NumberFormat('fr-TN').format(mileage) + ' km';
+  };
+
+  const handleFavorite = () => {
+    const fav = isFavorite(listing.id);
+    toggleFavorite(listing.id);
+    toast({
+      title: fav ? 'Retiré des favoris' : 'Ajouté aux favoris',
+    });
   };
 
   return (
@@ -122,8 +136,14 @@ const ListingCard: React.FC<ListingCardProps> = ({ listing, showActions = true }
                 size="sm"
                 variant="outline"
                 className="border-accent hover:bg-accent"
+                onClick={handleFavorite}
               >
-                <Heart className="h-4 w-4" />
+                <Heart
+                  className={cn(
+                    'h-4 w-4',
+                    isFavorite(listing.id) && 'fill-brand-700 text-brand-700'
+                  )}
+                />
               </Button>
             </div>
           </CardFooter>

--- a/src/components/MotoCard.tsx
+++ b/src/components/MotoCard.tsx
@@ -8,6 +8,9 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardFooter } from '@/components/ui/card';
 import { Eye, Heart, TrendingUp } from 'lucide-react';
+import { useFavorites } from '@/hooks/use-favorites';
+import { useToast } from '@/hooks/use-toast';
+import { cn } from '@/lib/utils';
 
 interface MotoCardProps {
   version: {
@@ -42,12 +45,23 @@ const MotoCard: React.FC<MotoCardProps> = ({
   brand, 
   showActions = true 
 }) => {
+  const { toggleFavorite, isFavorite } = useFavorites();
+  const { toast } = useToast();
+
   const formatPrice = (price: number) => {
     return new Intl.NumberFormat('fr-TN', {
       style: 'currency',
       currency: 'TND',
       minimumFractionDigits: 0,
     }).format(price).replace('TND', 'TND');
+  };
+
+  const handleFavorite = () => {
+    const fav = isFavorite(version.id);
+    toggleFavorite(version.id);
+    toast({
+      title: fav ? 'Retiré des favoris' : 'Ajouté aux favoris',
+    });
   };
 
   return (
@@ -121,8 +135,14 @@ const MotoCard: React.FC<MotoCardProps> = ({
                 size="sm"
                 variant="outline"
                 className="border-accent hover:bg-accent"
+                onClick={handleFavorite}
               >
-                <Heart className="h-4 w-4" />
+                <Heart
+                  className={cn(
+                    'h-4 w-4',
+                    isFavorite(version.id) && 'fill-brand-700 text-brand-700'
+                  )}
+                />
               </Button>
               <Button
                 size="sm"


### PR DESCRIPTION
## Summary
- add favorites context and hook
- enable toggling favorites with toast on MotoCard and ListingCard
- wrap app with favorites provider and toaster

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt, unable to run to completion)*

------
https://chatgpt.com/codex/tasks/task_e_68af347d95a0832b93e4cc47428dc6f8