### PR TITLE
feat: add shared moto types

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,9 +8,10 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import MotoCard from '@/components/MotoCard';
 import { ArrowRight, Search, TrendingUp, Users, Award, MapPin, ChevronRight } from 'lucide-react';
+import { Moto, Version, Model, Brand } from '@/types';
 
 export default function Home() {
-  const [featuredMotos, setFeaturedMotos] = useState<any[]>([]);
+  const [featuredMotos, setFeaturedMotos] = useState<Moto[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -25,14 +26,14 @@ export default function Home() {
         fetch('/api/brands')
       ]);
 
-      const versions = await versionsRes.json();
-      const models = await modelsRes.json();
-      const brands = await brandsRes.json();
+      const versions: Version[] = await versionsRes.json();
+      const models: Model[] = await modelsRes.json();
+      const brands: Brand[] = await brandsRes.json();
 
       // Get 6 featured motos (mix of different categories)
-      const featured = versions.slice(0, 6).map((version: any) => {
-        const model = models.find((m: any) => m.id === version.modelId);
-        const brand = brands.find((b: any) => b.id === model?.brandId);
+      const featured: Moto[] = versions.slice(0, 6).map((version: Version) => {
+        const model = models.find((m: Model) => m.id === version.modelId);
+        const brand = brands.find((b: Brand) => b.id === model?.brandId);
         return { version, model, brand };
       });
 

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -5,40 +5,12 @@ import { motion } from 'framer-motion';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Badge } from '@/components/ui/badge';
 import { CheckCircle, XCircle, X } from 'lucide-react';
+import { Version, FeatureValue, FeatureComparison } from '@/types';
 
 interface CompareTableProps {
   comparisonData: {
-    versions: Array<{
-      id: string;
-      name: string;
-      price: number;
-      engine: {
-        displacement: number;
-        type: string;
-        power: number;
-        torque: number;
-      };
-      performance: {
-        topSpeed: number;
-        acceleration: number;
-        weight: number;
-      };
-      dimensions: {
-        length: number;
-        width: number;
-        height: number;
-        wheelbase: number;
-      };
-      features: {
-        abs: boolean;
-        tcs: boolean;
-        quickshifter: boolean;
-        cruiseControl: boolean;
-        ledLights: boolean;
-      };
-    }>;
+    versions: Version[];
     similarities: {
       engine: string[];
       performance: string[];
@@ -47,48 +19,12 @@ interface CompareTableProps {
       comfort: string[];
     };
     differences: {
-      engine: Array<{
-        feature: string;
-        values: Array<{
-          version: string;
-          value: any;
-        }>;
-      }>;
-      performance: Array<{
-        feature: string;
-        values: Array<{
-          version: string;
-          value: any;
-        }>;
-      }>;
-      dimensions: Array<{
-        feature: string;
-        values: Array<{
-          version: string;
-          value: any;
-        }>;
-      }>;
-      safety: Array<{
-        feature: string;
-        values: Array<{
-          version: string;
-          value: any;
-        }>;
-      }>;
-      comfort: Array<{
-        feature: string;
-        values: Array<{
-          version: string;
-          value: any;
-        }>;
-      }>;
-      price: Array<{
-        feature: string;
-        values: Array<{
-          version: string;
-          value: number;
-        }>;
-      }>;
+      engine: FeatureComparison[];
+      performance: FeatureComparison[];
+      dimensions: FeatureComparison[];
+      safety: FeatureComparison[];
+      comfort: FeatureComparison[];
+      price: FeatureComparison[];
     };
   };
   onRemoveVersion?: (versionId: string) => void;
@@ -105,7 +41,7 @@ const CompareTable: React.FC<CompareTableProps> = ({ comparisonData, onRemoveVer
     }).format(price).replace('TND', 'TND');
   };
 
-  const renderFeatureValue = (value: any) => {
+  const renderFeatureValue = (value: FeatureValue) => {
     if (typeof value === 'boolean') {
       return value ? (
         <CheckCircle className="h-5 w-5 text-green-500" />

--- a/src/components/FilterSidebar.tsx
+++ b/src/components/FilterSidebar.tsx
@@ -11,20 +11,13 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Filter, ChevronDown, X } from 'lucide-react';
+import { Filters } from '@/types';
 
 interface FilterSidebarProps {
   isOpen: boolean;
   onToggle: () => void;
-  filters: {
-    brands: string[];
-    categories: string[];
-    priceRange: [number, number];
-    engineRange: [number, number];
-    powerRange: [number, number];
-    selectedBrands: string[];
-    selectedCategories: string[];
-  };
-  onFiltersChange: (filters: any) => void;
+  filters: Filters;
+  onFiltersChange: (filters: Filters) => void;
 }
 
 const FilterSidebar: React.FC<FilterSidebarProps> = ({

--- a/src/components/MotoCard.tsx
+++ b/src/components/MotoCard.tsx
@@ -11,31 +11,12 @@ import { Eye, Heart, TrendingUp } from 'lucide-react';
 import { useFavorites } from '@/hooks/use-favorites';
 import { useToast } from '@/hooks/use-toast';
 import { cn } from '@/lib/utils';
+import { Version, Model, Brand } from '@/types';
 
 interface MotoCardProps {
-  version: {
-    id: string;
-    modelId: string;
-    name: string;
-    price: number;
-    engine: {
-      displacement: number;
-      power: number;
-    };
-    performance: {
-      topSpeed: number;
-      weight: number;
-    };
-  };
-  model?: {
-    name: string;
-    brandId: string;
-    category: string;
-    image: string;
-  };
-  brand?: {
-    name: string;
-  };
+  version: Version;
+  model?: Model;
+  brand?: Brand;
   showActions?: boolean;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,79 @@
+export interface Brand {
+  id: string;
+  name: string;
+  logo?: string;
+  description?: string;
+  founded?: number;
+  country?: string;
+}
+
+export interface Model {
+  id: string;
+  name: string;
+  brandId: string;
+  category: string;
+  image: string;
+  description?: string;
+}
+
+export interface EngineSpecs {
+  displacement: number;
+  type: string;
+  power: number;
+  torque: number;
+}
+
+export interface PerformanceSpecs {
+  topSpeed: number;
+  acceleration: number;
+  weight: number;
+}
+
+export interface Dimensions {
+  length: number;
+  width: number;
+  height: number;
+  wheelbase: number;
+}
+
+export interface Features {
+  abs: boolean;
+  tcs: boolean;
+  quickshifter: boolean;
+  cruiseControl: boolean;
+  ledLights: boolean;
+}
+
+export interface Version {
+  id: string;
+  modelId: string;
+  name: string;
+  price: number;
+  engine: EngineSpecs;
+  performance: PerformanceSpecs;
+  dimensions: Dimensions;
+  features: Features;
+}
+
+export interface Moto {
+  version: Version;
+  model?: Model;
+  brand?: Brand;
+}
+
+export interface Filters {
+  brands: string[];
+  categories: string[];
+  priceRange: [number, number];
+  engineRange: [number, number];
+  powerRange: [number, number];
+  selectedBrands: string[];
+  selectedCategories: string[];
+}
+
+export type FeatureValue = string | number | boolean;
+
+export interface FeatureComparison {
+  feature: string;
+  values: Array<{ version: string; value: FeatureValue }>;
+}


### PR DESCRIPTION
## Summary
- add shared interfaces for motos, versions and filters
- use strong types instead of `any` in home, sidebar and comparison table
- update MotoCard to leverage new shared types

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(failed: prompts for ESLint configuration)*
- `npm run build` *(failed: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_68af418582b8832b9b5729cb3e632b8d