### PR TITLE
Improve error handling for homepage API requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.next

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,7 +15,7 @@ export default function Home() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchFeaturedMotos = useCallback(async () => {
+  const fetchFeaturedMotos = useCallback(async (): Promise<string | void> => {
     setLoading(true);
     setError(null);
     try {
@@ -25,6 +25,16 @@ export default function Home() {
         fetch('/api/models'),
         fetch('/api/brands')
       ]);
+
+      if (!versionsRes.ok) {
+        throw new Error('Erreur lors de la récupération des versions.');
+      }
+      if (!modelsRes.ok) {
+        throw new Error('Erreur lors de la récupération des modèles.');
+      }
+      if (!brandsRes.ok) {
+        throw new Error('Erreur lors de la récupération des marques.');
+      }
 
       const versions: Version[] = await versionsRes.json();
       const models: Model[] = await modelsRes.json();
@@ -40,7 +50,12 @@ export default function Home() {
       setFeaturedMotos(featured);
     } catch (error) {
       console.error('Error fetching featured motos:', error);
-      setError("Erreur lors du chargement des motos en vedette.");
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Erreur lors du chargement des motos en vedette.';
+      setError(message);
+      return message;
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- validate API responses for versions, models, and brands before parsing
- surface specific error messages when each API call fails
- add gitignore for node_modules and Next.js build output

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af45289cd0832bb1064144356d044f