### PR TITLE
chore: remove static export config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,10 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'export',
   eslint: {
     ignoreDuringBuilds: true,
   },
-  images: { unoptimized: true },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- remove static export mode to enable serverless functions
- drop unoptimized image config

## Testing
- `npm run build` *(fails: Failed to fetch `Inter` font from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68af47f51fa8832baa7fc455e54bd1f6