### PR TITLE
chore: update TypeScript target

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2015",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
@@ -18,6 +18,7 @@
         "name": "next"
       }
     ],
+    "downlevelIteration": true,
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## Summary
- target ES2015 in TypeScript config and enable downlevel iteration

## Testing
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68af4cac0bf0832baa340072f1fb654a