### PR TITLE
Add placeholder pages to resolve 404 navigation issues

### DIFF
--- a/src/app/concessionnaires/page.tsx
+++ b/src/app/concessionnaires/page.tsx
@@ -1,0 +1,8 @@
+export default function ConcessionnairesPage() {
+  return (
+    <div className="p-8">
+      <h1 className="text-3xl font-bold text-fg">Concessionnaires</h1>
+      <p className="mt-4 text-muted">Liste des concessionnaires à venir.</p>
+    </div>
+  );
+}

--- a/src/app/guide/page.tsx
+++ b/src/app/guide/page.tsx
@@ -1,0 +1,8 @@
+export default function GuidePage() {
+  return (
+    <div className="p-8">
+      <h1 className="text-3xl font-bold text-fg">Guide pratique</h1>
+      <p className="mt-4 text-muted">Contenu à venir.</p>
+    </div>
+  );
+}

--- a/src/app/mag/page.tsx
+++ b/src/app/mag/page.tsx
@@ -1,0 +1,8 @@
+export default function MagPage() {
+  return (
+    <div className="p-8">
+      <h1 className="text-3xl font-bold text-fg">Magazine</h1>
+      <p className="mt-4 text-muted">Les articles arriveront prochainement.</p>
+    </div>
+  );
+}

--- a/src/app/motos/[brandId]/[model]/page.tsx
+++ b/src/app/motos/[brandId]/[model]/page.tsx
@@ -1,0 +1,13 @@
+interface PageProps {
+  params: { brandId: string; model: string };
+}
+
+export default function MotoDetailsPage({ params }: PageProps) {
+  const { brandId, model } = params;
+  return (
+    <div className="p-8">
+      <h1 className="text-3xl font-bold text-fg">Détails du modèle {model}</h1>
+      <p className="mt-4 text-muted">Marque #{brandId} - page en construction.</p>
+    </div>
+  );
+}

--- a/src/app/motos/comparateur/page.tsx
+++ b/src/app/motos/comparateur/page.tsx
@@ -1,0 +1,8 @@
+export default function ComparateurPage() {
+  return (
+    <div className="p-8">
+      <h1 className="text-3xl font-bold text-fg">Comparateur</h1>
+      <p className="mt-4 text-muted">Fonctionnalité en cours de développement.</p>
+    </div>
+  );
+}

--- a/src/app/motos/page.tsx
+++ b/src/app/motos/page.tsx
@@ -1,0 +1,8 @@
+export default function MotosPage() {
+  return (
+    <div className="p-8">
+      <h1 className="text-3xl font-bold text-fg">Catalogue des motos</h1>
+      <p className="mt-4 text-muted">Cette page est en construction.</p>
+    </div>
+  );
+}

--- a/src/app/occasion/page.tsx
+++ b/src/app/occasion/page.tsx
@@ -1,0 +1,8 @@
+export default function OccasionPage() {
+  return (
+    <div className="p-8">
+      <h1 className="text-3xl font-bold text-fg">Marché d'occasion</h1>
+      <p className="mt-4 text-muted">Cette section sera bientôt disponible.</p>
+    </div>
+  );
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,13 @@
+interface SearchPageProps {
+  searchParams: { query?: string };
+}
+
+export default function SearchPage({ searchParams }: SearchPageProps) {
+  const query = searchParams.query || '';
+  return (
+    <div className="p-8">
+      <h1 className="text-3xl font-bold text-fg">Recherche</h1>
+      <p className="mt-4 text-muted">Résultats pour : {query || 'aucune recherche'}.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add initial /motos catalogue page
- stub out comparison and model detail routes
- create placeholders for occasion, mag, guide, concessionnaires and search

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68af67245654832bbd6bb0659ebfca91