### PR TITLE
feat(types): add moto model and variant definitions

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -77,3 +77,12 @@ export interface FeatureComparison {
   feature: string;
   values: Array<{ version: string; value: FeatureValue }>;
 }
+
+export type {
+  SpecValue,
+  SpecItem,
+  SpecFamily,
+  MotoVariant,
+  MotoModel
+} from './moto';
+

--- a/src/types/moto.ts
+++ b/src/types/moto.ts
@@ -1,0 +1,30 @@
+export type SpecValue = string | number | boolean;
+
+export interface SpecItem {
+  label: string;
+  value: SpecValue;
+}
+
+export interface SpecFamily {
+  group: string;
+  items: SpecItem[];
+}
+
+export interface MotoVariant {
+  id: string;
+  name: string;
+  price?: number;
+  specs: SpecFamily[];
+}
+
+export interface MotoModel {
+  id: string;
+  name: string;
+  brandId: string;
+  category: string;
+  image: string;
+  description?: string;
+  gallery?: string[];
+  variant?: MotoVariant[];
+}
+


### PR DESCRIPTION
## Summary
- add types for motorcycle specs, variants and models
- re-export moto types from types index

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: required configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68af6e1c5964832bac2ecd272487cbe6