### PR TITLE
feat: add presence utility for specs

### DIFF
--- a/scripts/seed-motos.ts
+++ b/scripts/seed-motos.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import * as XLSX from 'xlsx';
-import { isPresent } from '../src/lib/utils';
+import { isPresent } from '../src/lib/is-present';
 
 interface MotoModel {
   name: string;

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { CheckCircle, XCircle, X } from 'lucide-react';
 import { Version, FeatureValue, FeatureComparison } from '@/types';
+import { isPresent, tokens } from '@/lib/is-present';
 
 interface CompareTableProps {
   comparisonData: {
@@ -41,19 +42,30 @@ const CompareTable: React.FC<CompareTableProps> = ({ comparisonData, onRemoveVer
     }).format(price).replace('TND', 'TND');
   };
 
-  const renderFeatureValue = (value: FeatureValue) => {
-    if (typeof value === 'boolean') {
-      return value ? (
-        <CheckCircle className="h-5 w-5 text-green-500" />
-      ) : (
-        <XCircle className="h-5 w-5 text-red-500" />
-      );
-    }
-    if (typeof value === 'number') {
-      return <span className="font-medium">{value.toLocaleString()}</span>;
-    }
-    return <span>{value}</span>;
-  };
+    const renderFeatureValue = (value: FeatureValue) => {
+      if (!isPresent(value)) return null;
+      if (typeof value === 'boolean') {
+        return value ? (
+          <CheckCircle className="h-5 w-5 text-green-500" />
+        ) : (
+          <XCircle className="h-5 w-5 text-red-500" />
+        );
+      }
+      if (typeof value === 'number') {
+        return <span className="font-medium">{value.toLocaleString()}</span>;
+      }
+      const parts = tokens(value);
+      if (parts.length > 1) {
+        return (
+          <ul className="space-y-1">
+            {parts.map((token, idx) => (
+              <li key={idx}>{token}</li>
+            ))}
+          </ul>
+        );
+      }
+      return <span>{parts[0]}</span>;
+    };
 
   const SimilaritiesTab = () => (
     <div className="space-y-6">
@@ -71,17 +83,20 @@ const CompareTable: React.FC<CompareTableProps> = ({ comparisonData, onRemoveVer
             </CardHeader>
             <CardContent>
               <ul className="space-y-2">
-                {items.map((item, index) => (
-                  <li key={index} className="flex items-center space-x-2">
-                    <CheckCircle className="h-4 w-4 text-green-500 flex-shrink-0" />
-                    <span className="text-fg">{item}</span>
-                  </li>
-                ))}
-              </ul>
-            </CardContent>
-          </Card>
-        )
-      ))}
+                  {items
+                    .filter(isPresent)
+                    .flatMap(tokens)
+                    .map((item, index) => (
+                      <li key={index} className="flex items-center space-x-2">
+                        <CheckCircle className="h-4 w-4 text-green-500 flex-shrink-0" />
+                        <span className="text-fg">{item}</span>
+                      </li>
+                    ))}
+                </ul>
+              </CardContent>
+            </Card>
+          )
+        ))}
     </div>
   );
 
@@ -172,8 +187,30 @@ const CompareTable: React.FC<CompareTableProps> = ({ comparisonData, onRemoveVer
                   {formatPrice(version.price)}
                 </div>
                 <div className="space-y-1 text-sm text-muted">
-                  <div>{version.engine.displacement}cc - {version.engine.power}ch</div>
-                  <div>{version.performance.topSpeed} km/h - {version.performance.weight}kg</div>
+                  <div>
+                    {[
+                      isPresent(version.engine.displacement)
+                        ? `${version.engine.displacement}cc`
+                        : null,
+                      isPresent(version.engine.power)
+                        ? `${version.engine.power}ch`
+                        : null,
+                    ]
+                      .filter(isPresent)
+                      .join(' - ')}
+                  </div>
+                  <div>
+                    {[
+                      isPresent(version.performance.topSpeed)
+                        ? `${version.performance.topSpeed} km/h`
+                        : null,
+                      isPresent(version.performance.weight)
+                        ? `${version.performance.weight}kg`
+                        : null,
+                    ]
+                      .filter(isPresent)
+                      .join(' - ')}
+                  </div>
                 </div>
               </div>
             ))}

--- a/src/components/MotoCard.tsx
+++ b/src/components/MotoCard.tsx
@@ -11,6 +11,7 @@ import { Eye, Heart, TrendingUp } from 'lucide-react';
 import { useFavorites } from '@/hooks/use-favorites';
 import { useToast } from '@/hooks/use-toast';
 import { cn } from '@/lib/utils';
+import { isPresent } from '@/lib/is-present';
 import { Version, Model, Brand } from '@/types';
 
 interface MotoCardProps {
@@ -81,22 +82,30 @@ const MotoCard: React.FC<MotoCardProps> = ({
             <p className="text-sm text-muted">{version.name}</p>
           </div>
 
-          {/* Specs */}
-          <div className="flex justify-between text-sm text-muted mb-3">
-            <span>{version.engine.displacement}cc</span>
-            <span>{version.engine.power}ch</span>
-            <span>{version.performance.weight}kg</span>
-          </div>
+            {/* Specs */}
+            <div className="flex justify-between text-sm text-muted mb-3">
+              {isPresent(version.engine.displacement) && (
+                <span>{version.engine.displacement}cc</span>
+              )}
+              {isPresent(version.engine.power) && (
+                <span>{version.engine.power}ch</span>
+              )}
+              {isPresent(version.performance.weight) && (
+                <span>{version.performance.weight}kg</span>
+              )}
+            </div>
 
           {/* Price */}
           <div className="flex items-center justify-between">
             <div className="text-xl font-bold text-brand-300">
               {formatPrice(version.price)}
             </div>
-            <div className="text-sm text-muted">
-              {version.performance.topSpeed} km/h
+              {isPresent(version.performance.topSpeed) && (
+                <div className="text-sm text-muted">
+                  {version.performance.topSpeed} km/h
+                </div>
+              )}
             </div>
-          </div>
         </CardContent>
 
         {showActions && (

--- a/src/lib/is-present.ts
+++ b/src/lib/is-present.ts
@@ -1,0 +1,10 @@
+export function isPresent<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined && value !== '' && value !== '-';
+}
+
+export function tokens(value: string): string[] {
+  return value
+    .split('|')
+    .map((token) => token.trim())
+    .filter((token) => isPresent(token));
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,7 +4,3 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
-
-export function isPresent<T>(value: T | null | undefined): value is T {
-  return value !== null && value !== undefined && value !== '' && value !== '-';
-}


### PR DESCRIPTION
## Summary
- add spec presence and token helpers
- apply presence checks to moto comparison and cards
- update seed script to use presence helper

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68af704a57a8832b83aa53b7bf62a190