### PR TITLE
feat: add compare hook and page

### DIFF
--- a/src/app/motos/comparateur/page.tsx
+++ b/src/app/motos/comparateur/page.tsx
@@ -1,8 +1,35 @@
+'use client';
+
+import modelsData from '@/data/models.json';
+import { Button } from '@/components/ui/button';
+import useCompare from '@/hooks/use-compare';
+import type { Model } from '@/types';
+
+const models = modelsData as Model[];
+
 export default function ComparateurPage() {
+  const { compareMotos, removeMoto } = useCompare();
+  const selectedModels = models.filter((m) => compareMotos.includes(m.id));
+
   return (
     <div className="p-8">
       <h1 className="text-3xl font-bold text-fg">Comparateur</h1>
-      <p className="mt-4 text-muted">Fonctionnalité en cours de développement.</p>
+      {selectedModels.length === 0 ? (
+        <p className="mt-4 text-muted">
+          Aucun modèle sélectionné pour comparaison.
+        </p>
+      ) : (
+        <ul className="mt-4 space-y-2">
+          {selectedModels.map((model) => (
+            <li key={model.id} className="flex items-center gap-2">
+              <span className="text-fg">{model.name}</span>
+              <Button size="sm" variant="ghost" onClick={() => removeMoto(model.id)}>
+                Retirer
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/src/components/moto/CompareButton.tsx
+++ b/src/components/moto/CompareButton.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
+import useCompare from '@/hooks/use-compare';
 import { isPresent } from '@/lib/is-present';
 
 interface CompareButtonProps {
@@ -11,27 +11,19 @@ interface CompareButtonProps {
 
 export default function CompareButton({ modelId }: CompareButtonProps) {
   const { toast } = useToast();
-  const [active, setActive] = useState(false);
+  const { compareMotos, addMoto, removeMoto } = useCompare();
 
-  useEffect(() => {
-    if (!isPresent(modelId)) return;
-    const stored = JSON.parse(localStorage.getItem('compare-models') || '[]') as string[];
-    setActive(stored.includes(modelId));
-  }, [modelId]);
+  const active = isPresent(modelId) && compareMotos.includes(modelId);
 
   const toggle = () => {
     if (!isPresent(modelId)) return;
-    const stored = JSON.parse(localStorage.getItem('compare-models') || '[]') as string[];
-    let updated: string[];
-    if (stored.includes(modelId)) {
-      updated = stored.filter((id) => id !== modelId);
+    if (active) {
+      removeMoto(modelId);
       toast({ title: 'Modèle retiré de la comparaison' });
     } else {
-      updated = [...stored, modelId];
+      addMoto(modelId);
       toast({ title: 'Modèle ajouté à la comparaison' });
     }
-    localStorage.setItem('compare-models', JSON.stringify(updated));
-    setActive(updated.includes(modelId));
   };
 
   return (

--- a/src/hooks/use-compare.ts
+++ b/src/hooks/use-compare.ts
@@ -1,0 +1,38 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'compareMotos';
+
+export default function useCompare() {
+  const [compareMotos, setCompareMotos] = useState<string[]>([]);
+
+  useEffect(() => {
+    try {
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]') as string[];
+      setCompareMotos(stored);
+    } catch {
+      // ignore parse errors
+      setCompareMotos([]);
+    }
+  }, []);
+
+  const addMoto = useCallback((id: string) => {
+    setCompareMotos((prev) => {
+      const updated = prev.includes(id) ? prev : [...prev, id];
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+      return updated;
+    });
+  }, []);
+
+  const removeMoto = useCallback((id: string) => {
+    setCompareMotos((prev) => {
+      const updated = prev.filter((m) => m !== id);
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+      return updated;
+    });
+  }, []);
+
+  return { compareMotos, addMoto, removeMoto };
+}
+


### PR DESCRIPTION
## Summary
- manage compare list with new `useCompare` hook backed by `localStorage`
- simplify `CompareButton` using `useCompare` helpers
- show selected models on comparateur page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68af7f772ff4832bb505caeb14a1bf05