### PR TITLE
feat: add similar models section

### DIFF
--- a/src/app/motos/[brand]/[model]/[[...variant]]/page.tsx
+++ b/src/app/motos/[brand]/[model]/[[...variant]]/page.tsx
@@ -102,16 +102,9 @@ export default async function MotoPage({ params }: PageProps) {
   const priceStr = general['Prix (TND)'];
   const priceTND = priceStr ? parseInt(priceStr.replace(/\s/g, ''), 10) : undefined;
 
-  const similarModels = motos
-    .filter(
-      (m) =>
-        m !== moto &&
-        m['Informations générales']['Marque'] === brandName
-    )
-    .map((m) => ({
-      name: m['Informations générales']['Modèle'],
-      slug: slugify(m['Informations générales']['Modèle']),
-    }));
+  const category = general['Catégorie']
+    ? slugify(general['Catégorie'])
+    : undefined;
 
   const families: SpecFamily[] = Object.entries(moto)
     .filter(([k]) => k !== 'name' && k !== 'Informations générales')
@@ -191,7 +184,11 @@ export default async function MotoPage({ params }: PageProps) {
         </TabsContent>
       </Tabs>
 
-      <SimilarModels brand={params.brand} models={similarModels} />
+      <SimilarModels
+        brand={params.brand}
+        model={params.model}
+        category={category}
+      />
 
       {jsonLd && (
         <script

--- a/src/components/moto/SimilarModels.tsx
+++ b/src/components/moto/SimilarModels.tsx
@@ -1,29 +1,82 @@
+import { promises as fs } from 'fs';
+import path from 'path';
 import Link from 'next/link';
-import { isPresent } from '@/lib/is-present';
+import { Card } from '@/components/ui/card';
 
-interface SimilarModel {
-  name?: string | null;
-  slug?: string | null;
+function slugify(str: string) {
+  return str
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
 }
 
 interface SimilarModelsProps {
-  brand: string;
-  models: SimilarModel[];
+  brand?: string;
+  category?: string;
+  model?: string;
 }
 
-export default function SimilarModels({ brand, models }: SimilarModelsProps) {
-  const list = models
-    .filter((m) => isPresent(m.slug) && isPresent(m.name))
-    .slice(0, 6) as { name: string; slug: string }[];
+export default async function SimilarModels({
+  brand,
+  category,
+  model,
+}: SimilarModelsProps) {
+  const file = await fs.readFile(
+    path.join(process.cwd(), 'data', 'motos.json'),
+    'utf-8'
+  );
+  const motos = JSON.parse(file) as any[];
+
+  const brandSlug = brand ? slugify(brand) : undefined;
+  const categorySlug = category ? slugify(category) : undefined;
+  const currentModelSlug = model ? slugify(model) : undefined;
+
+  const list = motos
+    .filter((m) => {
+      const general = m['Informations générales'] || {};
+      const mBrand = slugify(general['Marque'] || '');
+      const mModel = slugify(general['Modèle'] || '');
+      const mCategory = general['Catégorie']
+        ? slugify(general['Catégorie'])
+        : undefined;
+      const sameCategory = categorySlug
+        ? mCategory === categorySlug
+        : true;
+      const sameBrand = brandSlug ? mBrand === brandSlug : true;
+      const same = categorySlug ? sameCategory : sameBrand;
+      const notCurrent = currentModelSlug ? mModel !== currentModelSlug : true;
+      return same && notCurrent;
+    })
+    .map((m) => {
+      const general = m['Informations générales'];
+      return {
+        name: general['Modèle'] as string,
+        slug: slugify(general['Modèle'] || ''),
+        brandSlug: slugify(general['Marque'] || ''),
+        brandName: general['Marque'] as string,
+      };
+    })
+    .slice(0, 6);
+
   if (list.length < 3) return null;
+
   return (
     <section className="mt-12">
       <h2 className="mb-4 text-xl font-bold text-fg">Modèles similaires</h2>
       <ul className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
         {list.map((m) => (
           <li key={m.slug}>
-            <Link href={`/motos/${brand}/${m.slug}`} className="hover:text-brand-500">
-              {m.name}
+            <Link
+              href={`/motos/${m.brandSlug}/${m.slug}`}
+              className="block hover:text-brand-500"
+            >
+              <Card className="p-4">
+                <h3 className="font-semibold text-fg">
+                  {m.brandName} {m.name}
+                </h3>
+              </Card>
             </Link>
           </li>
         ))}


### PR DESCRIPTION
## Summary
- load moto data within SimilarModels component and filter by brand or category
- render up to six compact cards linking to each model's detail page
- update model page to supply brand, model, and category props

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for ESLint config)


------
https://chatgpt.com/codex/tasks/task_e_68af80b80fb8832b8f2c18a8af6f71e5