### PR TITLE
feat: add moto ingestion script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_SITE_NAME=moto.tn

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "seed:motos": "ts-node scripts/seed-motos.ts"
+    "seed:motos": "ts-node scripts/seed-motos.ts",
+    "ingest:motos": "tsx scripts/ingest-motos.ts",
+    "typecheck": "tsc --noEmit",
+    "format": "prettier -w ."
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -67,9 +70,15 @@
     "tailwindcss": "3.3.3",
     "tailwindcss-animate": "^1.0.7",
     "ts-node": "^10.9.2",
-    "typescript": "5.2.2",
     "vaul": "^0.9.9",
     "xlsx": "^0.18.5",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "fs-extra": "^11.2.0",
+    "globby": "^14.0.1"
+  },
+  "devDependencies": {
+    "prettier": "^3.3.3",
+    "tsx": "^4.7.1",
+    "typescript": "5.2.2"
   }
 }

--- a/scripts/ingest-motos.ts
+++ b/scripts/ingest-motos.ts
@@ -1,0 +1,140 @@
+import path from "node:path";
+import { ensureDir, writeJSON } from "fs-extra";
+import { globby } from "globby";
+import * as XLSX from "xlsx";
+import type { Moto, SpecValue, Specs } from "../src/types/moto";
+
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function snakeCase(input: string): string {
+  return input
+    .replace(/[^a-zA-Z0-9]+/g, " ")
+    .trim()
+    .split(" ")
+    .map((w) => w.toLowerCase())
+    .join("_");
+}
+
+async function readExcelFiles(): Promise<Moto[]> {
+  const files = await globby("data/excel/**/*.{xlsx,xls}");
+  if (!files.length) {
+    console.log("No Excel files found in data/excel.");
+    return [];
+  }
+
+  const motos: Moto[] = [];
+
+  for (const file of files) {
+    const workbook = XLSX.readFile(file);
+    const sheetNames = workbook.SheetNames;
+    let bestSheetName = sheetNames[0];
+    let bestRows: any[] = [];
+
+    for (const name of sheetNames) {
+      const rows = XLSX.utils.sheet_to_json(workbook.Sheets[name], {
+        defval: null,
+      });
+      if (rows.length > bestRows.length) {
+        bestRows = rows;
+        bestSheetName = name;
+      }
+    }
+
+    for (const row of bestRows) {
+      const normalized: Record<string, SpecValue> = {};
+      for (const [key, value] of Object.entries(row)) {
+        normalized[snakeCase(key)] = value as SpecValue;
+      }
+
+      const brand = String(normalized["brand"] ?? "").trim();
+      const model = String(normalized["model"] ?? "").trim();
+
+      const moto: Moto = {
+        id:
+          String(normalized["id"]) ||
+          slugify(`${brand}-${model}-${Date.now()}`),
+        brand,
+        brandSlug: slugify(brand),
+        model,
+        modelSlug: slugify(model),
+        year:
+          normalized["year"] !== null && normalized["year"] !== undefined
+            ? Number(normalized["year"])
+            : undefined,
+        price:
+          normalized["price"] !== null && normalized["price"] !== undefined
+            ? Number(normalized["price"])
+            : undefined,
+        category: normalized["category"]?.toString(),
+        imageUrl: (normalized["image_url"] || normalized["image"])?.toString(),
+        specs: {},
+        sourceFile: path.basename(file),
+        sheet: bestSheetName,
+        createdAt: new Date().toISOString(),
+      };
+
+      const baseKeys = new Set([
+        "id",
+        "brand",
+        "brand_slug",
+        "model",
+        "model_slug",
+        "year",
+        "price",
+        "category",
+        "image_url",
+        "image",
+        "sourcefile",
+        "sheet",
+        "createdat",
+      ]);
+
+      const specs: Specs = {};
+      for (const [key, value] of Object.entries(normalized)) {
+        if (!baseKeys.has(key)) {
+          specs[key] = value;
+        }
+      }
+      moto.specs = specs;
+      motos.push(moto);
+    }
+  }
+
+  return motos;
+}
+
+async function writeOutputs(motos: Moto[]) {
+  await ensureDir("data/generated");
+  await writeJSON("data/generated/motos.json", motos, { spaces: 2 });
+
+  const byBrand: Record<string, Moto[]> = {};
+  for (const moto of motos) {
+    if (!byBrand[moto.brandSlug]) {
+      byBrand[moto.brandSlug] = [];
+    }
+    byBrand[moto.brandSlug].push(moto);
+  }
+
+  for (const [slug, list] of Object.entries(byBrand)) {
+    await writeJSON(`data/generated/motos_${slug}.json`, list, { spaces: 2 });
+  }
+}
+
+async function main() {
+  const motos = await readExcelFiles();
+  if (!motos.length) return;
+
+  await writeOutputs(motos);
+  console.log(`Generated ${motos.length} motos.`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -79,10 +79,7 @@ export interface FeatureComparison {
 }
 
 export type {
-  SpecValue,
-  SpecItem,
-  SpecFamily,
-  MotoVariant,
-  MotoModel
-} from './moto';
-
+  SpecValue as MotoSpecValue,
+  Specs as MotoSpecs,
+  Moto as MotoData,
+} from "./moto";

--- a/src/types/moto.ts
+++ b/src/types/moto.ts
@@ -1,30 +1,19 @@
-export type SpecValue = string | number | boolean;
+export type SpecValue = string | number | boolean | null;
 
-export interface SpecItem {
-  label: string;
-  value: SpecValue;
-}
+export type Specs = Record<string, SpecValue>;
 
-export interface SpecFamily {
-  group: string;
-  items: SpecItem[];
-}
-
-export interface MotoVariant {
+export interface Moto {
   id: string;
-  name: string;
+  brand: string;
+  brandSlug: string;
+  model: string;
+  modelSlug: string;
+  year?: number;
   price?: number;
-  specs: SpecFamily[];
+  category?: string;
+  imageUrl?: string;
+  specs: Specs;
+  sourceFile: string;
+  sheet?: string;
+  createdAt: string;
 }
-
-export interface MotoModel {
-  id: string;
-  name: string;
-  brandId: string;
-  category: string;
-  image: string;
-  description?: string;
-  gallery?: string[];
-  variant?: MotoVariant[];
-}
-


### PR DESCRIPTION
## Summary
- add moto ingestion script and supporting types
- configure package and env for moto ingestion

## Testing
- `npx prettier -w package.json scripts/ingest-motos.ts src/types/moto.ts src/types/index.ts .env.example`
- `npm run typecheck` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `npm run ingest:motos` *(fails: tsx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af84494f84832bbb4bba3f6d9e6d4e