### PR TITLE
feat: add moto search utilities

### DIFF
--- a/data/generated/motos.json
+++ b/data/generated/motos.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "1",
+    "brand": "Yamaha",
+    "brandSlug": "yamaha",
+    "model": "MT-07",
+    "modelSlug": "mt-07",
+    "year": 2023,
+    "price": 7000,
+    "category": "naked",
+    "imageUrl": null,
+    "specs": {
+      "engine": "689cc",
+      "horsepower": "73.4"
+    }
+  },
+  {
+    "id": "2",
+    "brand": "Honda",
+    "brandSlug": "honda",
+    "model": "CBR500R",
+    "modelSlug": "cbr500r",
+    "year": 2024,
+    "price": 6800,
+    "category": "sport",
+    "imageUrl": null,
+    "specs": {
+      "engine": "471cc",
+      "horsepower": "47"
+    }
+  }
+]

--- a/src/lib/motos.ts
+++ b/src/lib/motos.ts
@@ -1,0 +1,33 @@
+import motosData from "../../data/generated/motos.json" assert { type: "json" };
+import type { Moto } from "@/types/moto";
+
+// The generated JSON may not be type-safe by default. Cast through unknown
+// to satisfy TypeScript while trusting the data shape at runtime.
+const motos = motosData as unknown as Moto[];
+
+export function getAllMotos(): Moto[] {
+  return motos;
+}
+
+export function findByBrand(brandSlug: string): Moto[] {
+  return motos.filter((moto) => moto.brandSlug === brandSlug);
+}
+
+export function findById(id: string): Moto | undefined {
+  return motos.find((moto) => moto.id === id);
+}
+
+export function search(query: string): Moto[] {
+  if (!query) return motos;
+  const lowerQuery = query.toLowerCase();
+
+  return motos.filter((moto) => {
+    if (moto.brand.toLowerCase().includes(lowerQuery)) return true;
+    if (moto.model.toLowerCase().includes(lowerQuery)) return true;
+    return Object.entries(moto.specs).some(([key, value]) => {
+      if (key.toLowerCase().includes(lowerQuery)) return true;
+      if (value === undefined || value === null) return false;
+      return String(value).toLowerCase().includes(lowerQuery);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add lib functions to query motos JSON data

## Testing
- `npm run typecheck` *(fails: Cannot find module 'node:path')*
- `node /tmp/test.js`


------
https://chatgpt.com/codex/tasks/task_e_68af88a580bc832b8b295489e5ae6b39