### PR TITLE
Add brand listing and moto comparison pages

### DIFF
--- a/src/app/comparateur/CompareClient.tsx
+++ b/src/app/comparateur/CompareClient.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import React from 'react';
+import CompareTable from '@/components/CompareTable';
+import { Button } from '@/components/ui/button';
+import { getAllMotos } from '@/lib/motos';
+import useCompare from '@/hooks/use-compare';
+
+export default function CompareClient() {
+  const { compareMotos, clear } = useCompare();
+  const [motos, setMotos] = React.useState(() => {
+    const all = getAllMotos();
+    return all.filter((m) => compareMotos.includes(m.id));
+  });
+
+  React.useEffect(() => {
+    const all = getAllMotos();
+    setMotos(all.filter((m) => compareMotos.includes(m.id)));
+  }, [compareMotos]);
+
+  return (
+    <div className="p-8 space-y-4">
+      <h1 className="text-3xl font-bold">Comparateur</h1>
+      {motos.length > 0 && (
+        <Button onClick={clear} aria-label="Vider comparateur">
+          Vider comparateur
+        </Button>
+      )}
+      <CompareTable motos={motos} />
+    </div>
+  );
+}
+

--- a/src/app/comparateur/page.tsx
+++ b/src/app/comparateur/page.tsx
@@ -1,0 +1,41 @@
+import type { Metadata } from 'next';
+import CompareTable from '@/components/CompareTable';
+import { Button } from '@/components/ui/button';
+import { getAllMotos } from '@/lib/motos';
+import useCompare from '@/hooks/use-compare';
+import React from 'react';
+
+export const metadata: Metadata = {
+  title: 'Comparateur',
+  description: 'Comparez plusieurs modèles de motos',
+};
+
+export default function ComparateurPage() {
+  return <CompareClient />;
+}
+
+function CompareClient() {
+  'use client';
+  const { compareMotos, clear } = useCompare();
+  const [motos, setMotos] = React.useState(() => {
+    const all = getAllMotos();
+    return all.filter((m) => compareMotos.includes(m.id));
+  });
+
+  React.useEffect(() => {
+    const all = getAllMotos();
+    setMotos(all.filter((m) => compareMotos.includes(m.id)));
+  }, [compareMotos]);
+
+  return (
+    <div className="p-8 space-y-4">
+      <h1 className="text-3xl font-bold">Comparateur</h1>
+      {motos.length > 0 && (
+        <Button onClick={clear} aria-label="Vider comparateur">
+          Vider comparateur
+        </Button>
+      )}
+      <CompareTable motos={motos} />
+    </div>
+  );
+}

--- a/src/app/comparateur/page.tsx
+++ b/src/app/comparateur/page.tsx
@@ -1,9 +1,5 @@
 import type { Metadata } from 'next';
-import CompareTable from '@/components/CompareTable';
-import { Button } from '@/components/ui/button';
-import { getAllMotos } from '@/lib/motos';
-import useCompare from '@/hooks/use-compare';
-import React from 'react';
+import CompareClient from './CompareClient';
 
 export const metadata: Metadata = {
   title: 'Comparateur',
@@ -14,28 +10,3 @@ export default function ComparateurPage() {
   return <CompareClient />;
 }
 
-function CompareClient() {
-  'use client';
-  const { compareMotos, clear } = useCompare();
-  const [motos, setMotos] = React.useState(() => {
-    const all = getAllMotos();
-    return all.filter((m) => compareMotos.includes(m.id));
-  });
-
-  React.useEffect(() => {
-    const all = getAllMotos();
-    setMotos(all.filter((m) => compareMotos.includes(m.id)));
-  }, [compareMotos]);
-
-  return (
-    <div className="p-8 space-y-4">
-      <h1 className="text-3xl font-bold">Comparateur</h1>
-      {motos.length > 0 && (
-        <Button onClick={clear} aria-label="Vider comparateur">
-          Vider comparateur
-        </Button>
-      )}
-      <CompareTable motos={motos} />
-    </div>
-  );
-}

--- a/src/app/marques/BrandsClient.tsx
+++ b/src/app/marques/BrandsClient.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import React from 'react';
+import BrandCard from '@/components/BrandCard';
+import { Input } from '@/components/ui/input';
+
+interface BrandInfo {
+  name: string;
+  slug: string;
+  count: number;
+}
+
+export default function BrandsClient({ brands }: { brands: BrandInfo[] }) {
+  const [query, setQuery] = React.useState('');
+  const filtered = React.useMemo(
+    () =>
+      brands.filter((b) =>
+        b.name.toLowerCase().includes(query.toLowerCase())
+      ),
+    [brands, query]
+  );
+
+  return (
+    <div className="p-8 space-y-4">
+      <h1 className="text-3xl font-bold">Marques</h1>
+      <Input
+        placeholder="Rechercher une marque"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        aria-label="Rechercher une marque"
+      />
+      <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
+        {filtered.map((b) => (
+          <BrandCard
+            key={b.slug}
+            name={b.name}
+            count={b.count}
+            href={`/marques/${b.slug}`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/marques/[brandSlug]/page.tsx
+++ b/src/app/marques/[brandSlug]/page.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { findByBrand } from '@/lib/motos';
+
+interface PageProps {
+  params: { brandSlug: string };
+}
+
+export function generateMetadata({ params }: PageProps): Metadata {
+  const motos = findByBrand(params.brandSlug);
+  if (motos.length === 0) return { title: 'Marque' };
+  const brand = motos[0].brand;
+  return {
+    title: brand,
+    description: `Modèles de la marque ${brand}`,
+  };
+}
+
+export default function BrandPage({ params }: PageProps) {
+  const motos = findByBrand(params.brandSlug);
+  if (motos.length === 0) notFound();
+  const brand = motos[0].brand;
+
+  return (
+    <div className="p-8 space-y-4">
+      <h1 className="text-3xl font-bold">{brand}</h1>
+      <ul className="list-disc pl-5 space-y-1">
+        {motos.map((m) => (
+          <li key={m.id}>
+            <Link href={`/modeles/${m.id}`}>{m.model} {m.year}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/marques/page.tsx
+++ b/src/app/marques/page.tsx
@@ -1,0 +1,68 @@
+import type { Metadata } from 'next';
+import BrandCard from '@/components/BrandCard';
+import { Input } from '@/components/ui/input';
+import { getAllMotos } from '@/lib/motos';
+import React from 'react';
+
+export const metadata: Metadata = {
+  title: 'Marques',
+  description: 'Liste des marques de motos',
+};
+
+interface BrandInfo {
+  name: string;
+  slug: string;
+  count: number;
+}
+
+export default function MarquesPage() {
+  const allMotos = getAllMotos();
+  const map = new Map<string, BrandInfo>();
+
+  allMotos.forEach((m) => {
+    if (!map.has(m.brandSlug)) {
+      map.set(m.brandSlug, { name: m.brand, slug: m.brandSlug, count: 0 });
+    }
+    map.get(m.brandSlug)!.count += 1;
+  });
+
+  const brands = Array.from(map.values()).sort((a, b) =>
+    a.name.localeCompare(b.name)
+  );
+
+  return <BrandsClient brands={brands} />;
+}
+
+function BrandsClient({ brands }: { brands: BrandInfo[] }) {
+  'use client';
+  const [query, setQuery] = React.useState('');
+  const filtered = React.useMemo(
+    () =>
+      brands.filter((b) =>
+        b.name.toLowerCase().includes(query.toLowerCase())
+      ),
+    [brands, query]
+  );
+
+  return (
+    <div className="p-8 space-y-4">
+      <h1 className="text-3xl font-bold">Marques</h1>
+      <Input
+        placeholder="Rechercher une marque"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        aria-label="Rechercher une marque"
+      />
+      <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
+        {filtered.map((b) => (
+          <BrandCard
+            key={b.slug}
+            name={b.name}
+            count={b.count}
+            href={`/marques/${b.slug}`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/marques/page.tsx
+++ b/src/app/marques/page.tsx
@@ -1,8 +1,6 @@
 import type { Metadata } from 'next';
-import BrandCard from '@/components/BrandCard';
-import { Input } from '@/components/ui/input';
 import { getAllMotos } from '@/lib/motos';
-import React from 'react';
+import BrandsClient from './BrandsClient';
 
 export const metadata: Metadata = {
   title: 'Marques',
@@ -33,36 +31,3 @@ export default function MarquesPage() {
   return <BrandsClient brands={brands} />;
 }
 
-function BrandsClient({ brands }: { brands: BrandInfo[] }) {
-  'use client';
-  const [query, setQuery] = React.useState('');
-  const filtered = React.useMemo(
-    () =>
-      brands.filter((b) =>
-        b.name.toLowerCase().includes(query.toLowerCase())
-      ),
-    [brands, query]
-  );
-
-  return (
-    <div className="p-8 space-y-4">
-      <h1 className="text-3xl font-bold">Marques</h1>
-      <Input
-        placeholder="Rechercher une marque"
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-        aria-label="Rechercher une marque"
-      />
-      <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
-        {filtered.map((b) => (
-          <BrandCard
-            key={b.slug}
-            name={b.name}
-            count={b.count}
-            href={`/marques/${b.slug}`}
-          />
-        ))}
-      </div>
-    </div>
-  );
-}

--- a/src/app/modeles/[id]/page.tsx
+++ b/src/app/modeles/[id]/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from 'next/navigation';
 import Image from 'next/image';
 import SpecsTable from '@/components/SpecsTable';
 import { Button } from '@/components/ui/button';
-import useCompare from '@/hooks/use-compare';
+import AddToCompareButton from '@/components/AddToCompareButton';
 import { findById } from '@/lib/motos';
 
 interface PageProps {
@@ -50,15 +50,3 @@ export default function ModelePage({ params }: PageProps) {
   );
 }
 
-function AddToCompareButton({ id }: { id: string }) {
-  'use client';
-  const { compareMotos, addMoto } = useCompare();
-  const added = compareMotos.includes(id);
-  const handle = () => addMoto(id);
-
-  return (
-    <Button onClick={handle} disabled={added} aria-label="Ajouter au comparateur">
-      {added ? 'Ajouté' : 'Ajouter au comparateur'}
-    </Button>
-  );
-}

--- a/src/app/modeles/[id]/page.tsx
+++ b/src/app/modeles/[id]/page.tsx
@@ -1,0 +1,64 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import Image from 'next/image';
+import SpecsTable from '@/components/SpecsTable';
+import { Button } from '@/components/ui/button';
+import useCompare from '@/hooks/use-compare';
+import { findById } from '@/lib/motos';
+
+interface PageProps {
+  params: { id: string };
+}
+
+export function generateMetadata({ params }: PageProps): Metadata {
+  const moto = findById(params.id);
+  if (!moto) return { title: 'Modèle' };
+  const title = `${moto.brand} ${moto.model}${moto.year ? ` ${moto.year}` : ''}`;
+  return {
+    title,
+    description: `Fiche technique de ${title}`,
+  };
+}
+
+export default function ModelePage({ params }: PageProps) {
+  const moto = findById(params.id);
+  if (!moto) notFound();
+  const title = `${moto.brand} ${moto.model}${moto.year ? ` ${moto.year}` : ''}`;
+
+  return (
+    <div className="p-8 space-y-4">
+      <h1 className="text-3xl font-bold">{title}</h1>
+      {moto.imageUrl && (
+        <Image
+          src={moto.imageUrl}
+          alt={title}
+          width={600}
+          height={400}
+          className="w-full h-auto"
+        />
+      )}
+      {moto.price && (
+        <p className="font-medium">Prix: {moto.price} TND</p>
+      )}
+      <SpecsTable specs={moto.specs} />
+      <AddToCompareButton id={moto.id} />
+      <Button asChild variant="link">
+        <Link href="/comparateur">Voir le comparateur</Link>
+      </Button>
+    </div>
+  );
+}
+
+function AddToCompareButton({ id }: { id: string }) {
+  'use client';
+  const { compareMotos, addMoto } = useCompare();
+  const added = compareMotos.includes(id);
+  const handle = () => addMoto(id);
+
+  return (
+    <Button onClick={handle} disabled={added} aria-label="Ajouter au comparateur">
+      {added ? 'Ajouté' : 'Ajouter au comparateur'}
+    </Button>
+  );
+}

--- a/src/components/AddToCompareButton.tsx
+++ b/src/components/AddToCompareButton.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import useCompare from '@/hooks/use-compare';
+
+export default function AddToCompareButton({ id }: { id: string }) {
+  const { compareMotos, addMoto } = useCompare();
+  const added = compareMotos.includes(id);
+  const handle = () => addMoto(id);
+
+  return (
+    <Button onClick={handle} disabled={added} aria-label="Ajouter au comparateur">
+      {added ? 'Ajouté' : 'Ajouter au comparateur'}
+    </Button>
+  );
+}
+

--- a/src/components/BrandCard.tsx
+++ b/src/components/BrandCard.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface BrandCardProps {
+  name: string;
+  count: number;
+  href: string;
+}
+
+export default function BrandCard({ name, count, href }: BrandCardProps) {
+  return (
+    <Link href={href} aria-label={`Voir les modèles ${name}`}>
+      <Card className="hover:border-brand-500 transition-colors">
+        <CardHeader>
+          <CardTitle className="text-lg">{name}</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted">
+          {count} modèle{count > 1 ? 's' : ''}
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -1,250 +1,57 @@
-'use client';
-
-import React, { useState } from 'react';
-import { motion } from 'framer-motion';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { CheckCircle, XCircle, X } from 'lucide-react';
-import { Version, FeatureValue, FeatureComparison } from '@/types';
-import { isPresent, tokens } from '@/lib/is-present';
+import type { Moto, SpecValue } from '@/types/moto';
 
 interface CompareTableProps {
-  comparisonData: {
-    versions: Version[];
-    similarities: {
-      engine: string[];
-      performance: string[];
-      dimensions: string[];
-      safety: string[];
-      comfort: string[];
-    };
-    differences: {
-      engine: FeatureComparison[];
-      performance: FeatureComparison[];
-      dimensions: FeatureComparison[];
-      safety: FeatureComparison[];
-      comfort: FeatureComparison[];
-      price: FeatureComparison[];
-    };
-  };
-  onRemoveVersion?: (versionId: string) => void;
+  motos: Moto[];
 }
 
-const CompareTable: React.FC<CompareTableProps> = ({ comparisonData, onRemoveVersion }) => {
-  const [activeTab, setActiveTab] = useState('differences');
+function formatKey(key: string) {
+  return key
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
 
-  const formatPrice = (price: number) => {
-    return new Intl.NumberFormat('fr-TN', {
-      style: 'currency',
-      currency: 'TND',
-      minimumFractionDigits: 0,
-    }).format(price).replace('TND', 'TND');
-  };
+export default function CompareTable({ motos }: CompareTableProps) {
+  if (motos.length < 2) {
+    return (
+      <p className="text-muted">Ajoutez au moins deux modèles pour comparer.</p>
+    );
+  }
 
-    const renderFeatureValue = (value: FeatureValue) => {
-      if (!isPresent(value)) return null;
-      if (typeof value === 'boolean') {
-        return value ? (
-          <CheckCircle className="h-5 w-5 text-green-500" />
-        ) : (
-          <XCircle className="h-5 w-5 text-red-500" />
-        );
-      }
-      if (typeof value === 'number') {
-        return <span className="font-medium">{value.toLocaleString()}</span>;
-      }
-      const parts = tokens(value);
-      if (parts.length > 1) {
-        return (
-          <ul className="space-y-1">
-            {parts.map((token, idx) => (
-              <li key={idx}>{token}</li>
-            ))}
-          </ul>
-        );
-      }
-      return <span>{parts[0]}</span>;
-    };
-
-  const SimilaritiesTab = () => (
-    <div className="space-y-6">
-      {Object.entries(comparisonData.similarities).map(([category, items]) => (
-        items.length > 0 && (
-          <Card key={category} className="bg-surface border-accent">
-            <CardHeader>
-              <CardTitle className="text-lg text-fg capitalize">
-                {category === 'engine' && 'Moteur'}
-                {category === 'performance' && 'Performance'}
-                {category === 'dimensions' && 'Dimensions'}
-                {category === 'safety' && 'Sécurité'}
-                {category === 'comfort' && 'Confort'}
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <ul className="space-y-2">
-                  {items
-                    .filter(isPresent)
-                    .flatMap(tokens)
-                    .map((item, index) => (
-                      <li key={index} className="flex items-center space-x-2">
-                        <CheckCircle className="h-4 w-4 text-green-500 flex-shrink-0" />
-                        <span className="text-fg">{item}</span>
-                      </li>
-                    ))}
-                </ul>
-              </CardContent>
-            </Card>
-          )
-        ))}
-    </div>
-  );
-
-  const DifferencesTab = () => (
-    <div className="space-y-6">
-      {Object.entries(comparisonData.differences).map(([category, items]) => (
-        items.length > 0 && (
-          <Card key={category} className="bg-surface border-accent">
-            <CardHeader>
-              <CardTitle className="text-lg text-fg capitalize">
-                {category === 'engine' && 'Moteur'}
-                {category === 'performance' && 'Performance'}
-                {category === 'dimensions' && 'Dimensions'}
-                {category === 'safety' && 'Sécurité'}
-                {category === 'comfort' && 'Confort'}
-                {category === 'price' && 'Prix'}
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                {items.map((diff, index) => (
-                  <div key={index} className="overflow-x-auto">
-                    <table className="w-full">
-                      <thead>
-                        <tr className="border-b border-accent">
-                          <th className="text-left py-2 text-fg font-medium min-w-[150px]">
-                            {diff.feature}
-                          </th>
-                          {comparisonData.versions.map((version) => (
-                            <th key={version.id} className="text-center py-2 text-fg font-medium min-w-[120px]">
-                              <div className="truncate">{version.name.split(' ')[0]}</div>
-                            </th>
-                          ))}
-                        </tr>
-                      </thead>
-                      <tbody>
-                        <tr>
-                          <td className="py-2"></td>
-                          {comparisonData.versions.map((version) => {
-                            const versionValue = diff.values.find(v => v.version === version.name);
-                            return (
-                              <td key={version.id} className="text-center py-2">
-                                {versionValue && renderFeatureValue(versionValue.value)}
-                              </td>
-                            );
-                          })}
-                        </tr>
-                      </tbody>
-                    </table>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
-        )
-      ))}
-    </div>
+  const specKeys = Array.from(
+    new Set(motos.flatMap((m) => Object.keys(m.specs)))
   );
 
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 20 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.5 }}
-      className="space-y-6"
-    >
-      {/* Versions Header */}
-      <Card className="bg-surface border-accent">
-        <CardHeader>
-          <CardTitle className="text-xl text-fg">Comparaison des versions</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {comparisonData.versions.map((version) => (
-              <div key={version.id} className="bg-bg border border-accent rounded-lg p-4 relative">
-                {onRemoveVersion && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="absolute top-2 right-2 text-muted hover:text-fg"
-                    onClick={() => onRemoveVersion(version.id)}
-                  >
-                    <X className="h-4 w-4" />
-                  </Button>
-                )}
-                <h3 className="font-semibold text-fg mb-2 pr-8">{version.name}</h3>
-                <div className="text-2xl font-bold text-brand-300 mb-2">
-                  {formatPrice(version.price)}
-                </div>
-                <div className="space-y-1 text-sm text-muted">
-                  <div>
-                    {[
-                      isPresent(version.engine.displacement)
-                        ? `${version.engine.displacement}cc`
-                        : null,
-                      isPresent(version.engine.power)
-                        ? `${version.engine.power}ch`
-                        : null,
-                    ]
-                      .filter(isPresent)
-                      .join(' - ')}
-                  </div>
-                  <div>
-                    {[
-                      isPresent(version.performance.topSpeed)
-                        ? `${version.performance.topSpeed} km/h`
-                        : null,
-                      isPresent(version.performance.weight)
-                        ? `${version.performance.weight}kg`
-                        : null,
-                    ]
-                      .filter(isPresent)
-                      .join(' - ')}
-                  </div>
-                </div>
-              </div>
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr>
+            <th className="p-2 text-left">Spécifications</th>
+            {motos.map((m) => (
+              <th key={m.id} className="p-2 text-left">
+                {m.brand} {m.model}
+              </th>
             ))}
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Comparison Tabs */}
-      <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
-        <TabsList className="grid w-full grid-cols-2 bg-surface border border-accent">
-          <TabsTrigger 
-            value="differences" 
-            className="data-[state=active]:bg-brand-700 data-[state=active]:text-fg"
-          >
-            Différences
-          </TabsTrigger>
-          <TabsTrigger 
-            value="similarities"
-            className="data-[state=active]:bg-brand-700 data-[state=active]:text-fg"
-          >
-            Similitudes
-          </TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="differences" className="space-y-4">
-          <DifferencesTab />
-        </TabsContent>
-
-        <TabsContent value="similarities" className="space-y-4">
-          <SimilaritiesTab />
-        </TabsContent>
-      </Tabs>
-    </motion.div>
+          </tr>
+        </thead>
+        <tbody>
+          {specKeys.map((key) => (
+            <tr key={key} className="border-t border-accent">
+              <th className="p-2 text-left font-medium">{formatKey(key)}</th>
+              {motos.map((m) => (
+                <td key={m.id} className="p-2">
+                  {renderValue(m.specs[key])}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
-};
+}
 
-export default CompareTable;
+function renderValue(value: SpecValue | undefined) {
+  if (value === undefined || value === null) return '—';
+  return String(value);
+}

--- a/src/components/SpecsTable.tsx
+++ b/src/components/SpecsTable.tsx
@@ -1,0 +1,28 @@
+import type { SpecValue } from '@/types/moto';
+
+interface SpecsTableProps {
+  specs: Record<string, SpecValue>;
+}
+
+function formatKey(key: string) {
+  return key
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export default function SpecsTable({ specs }: SpecsTableProps) {
+  const entries = Object.entries(specs);
+
+  return (
+    <table className="min-w-full text-sm">
+      <tbody>
+        {entries.map(([key, value]) => (
+          <tr key={key} className="border-b border-accent">
+            <th className="p-2 text-left font-medium">{formatKey(key)}</th>
+            <td className="p-2">{value === null ? '—' : String(value)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/hooks/use-compare.ts
+++ b/src/hooks/use-compare.ts
@@ -2,7 +2,8 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
-const STORAGE_KEY = 'compareMotos';
+// LocalStorage key used for storing compared moto ids
+const STORAGE_KEY = 'compare:motos';
 
 export default function useCompare() {
   const [compareMotos, setCompareMotos] = useState<string[]>([]);
@@ -33,6 +34,11 @@ export default function useCompare() {
     });
   }, []);
 
-  return { compareMotos, addMoto, removeMoto };
+  const clear = useCallback(() => {
+    localStorage.removeItem(STORAGE_KEY);
+    setCompareMotos([]);
+  }, []);
+
+  return { compareMotos, addMoto, removeMoto, clear };
 }
 


### PR DESCRIPTION
## Summary
- add BrandCard, SpecsTable and simplified CompareTable components
- implement brand, model and compare pages using localStorage for selections
- store comparison IDs in `compare:motos` and support clearing

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next: not found)*
- `npm run typecheck` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68af8ae8667c832bb9b6ac6e8fceac67