### PR TITLE
fix: use generated motos data for lists and details

### DIFF
--- a/src/app/modeles/[id]/not-found.tsx
+++ b/src/app/modeles/[id]/not-found.tsx
@@ -2,7 +2,7 @@ export default function NotFound() {
   return (
     <main className="mx-auto max-w-3xl px-4 py-16">
       <h1 className="text-2xl font-semibold mb-2">Modèle introuvable</h1>
-      <p>Le modèle demandé n’existe pas. <a className="underline" href="/motos">Retourner à la liste</a></p>
+      <p>Le modèle demandé n’existe pas. <a className="underline" href="/motos">Retour à la liste</a></p>
     </main>
   );
 }

--- a/src/app/modeles/[id]/page.tsx
+++ b/src/app/modeles/[id]/page.tsx
@@ -2,11 +2,9 @@ import { notFound } from "next/navigation";
 import { findById } from "../../../lib/motos";
 import SpecsTable from "../../../components/SpecsTable";
 
-function InfoRow({ label, value }: { label: string; value?: string | number | null }) {
+function Row({ label, value }: { label: string; value?: string | number | null }) {
   if (value == null || value === "") return null;
-  return (
-    <p><span className="text-gray-500">{label}:</span> {value}</p>
-  );
+  return <p><span className="text-gray-500">{label}:</span> {value}</p>;
 }
 
 export default function ModelePage({ params }: { params: { id: string } }) {
@@ -14,6 +12,7 @@ export default function ModelePage({ params }: { params: { id: string } }) {
   if (!moto) return notFound();
 
   const { brand, model, year, price, category, imageUrl, specs } = moto;
+  const specCount = specs ? Object.keys(specs).length : 0;
 
   return (
     <main className="mx-auto max-w-5xl px-4 py-8">
@@ -26,12 +25,13 @@ export default function ModelePage({ params }: { params: { id: string } }) {
           {brand} {model}{year ? ` · ${year}` : ""}
         </h1>
         <div className="mt-2 space-y-1">
-          <InfoRow label="Prix" value={price ?? null} />
-          <InfoRow label="Catégorie" value={category ?? null} />
+          <Row label="Prix" value={price ?? null} />
+          <Row label="Catégorie" value={category ?? null} />
         </div>
         {imageUrl ? (
           <img src={imageUrl} alt={`${brand} ${model}`} className="mt-4 max-h-72 rounded-lg object-cover" />
         ) : null}
+        <p className="text-sm text-gray-500 mt-2">{specCount} caractéristiques techniques</p>
       </header>
 
       <section className="space-y-3">
@@ -39,7 +39,7 @@ export default function ModelePage({ params }: { params: { id: string } }) {
         <SpecsTable specs={specs || {}} />
       </section>
 
-      {/* DEBUG DEVELOPPER-FRIENDLY (retirer plus tard) */}
+      {/* Debug dev : retire après validation */}
       <details className="mt-6">
         <summary className="cursor-pointer text-sm text-gray-500">Voir JSON brut (debug)</summary>
         <pre className="mt-2 overflow-auto rounded bg-black/80 p-3 text-xs text-white">

--- a/src/app/motos/page.tsx
+++ b/src/app/motos/page.tsx
@@ -17,7 +17,8 @@ export default function MotosPage() {
 
   return (
     <main className="mx-auto max-w-6xl px-4 py-8">
-      <h1 className="text-3xl font-semibold mb-4">Motos neuves</h1>
+      <h1 className="text-3xl font-semibold mb-2">Motos neuves</h1>
+      <p className="text-sm text-gray-500 mb-4">({all.length} modèles chargés)</p>
       <input
         value={q}
         onChange={(e) => setQ(e.target.value)}
@@ -45,3 +46,4 @@ export default function MotosPage() {
     </main>
   );
 }
+

--- a/src/lib/motos.ts
+++ b/src/lib/motos.ts
@@ -16,3 +16,7 @@ export function findById(id: string): Moto | undefined {
   return ALL.find((m) => m.id === id);
 }
 
+export function findByBrand(brandSlug: string): Moto[] {
+  return ALL.filter((m) => m.brandSlug === brandSlug);
+}
+

--- a/src/lib/motos.ts
+++ b/src/lib/motos.ts
@@ -1,7 +1,13 @@
 import type { Moto } from "../types/moto";
-import data from "../../data/generated/motos.json" assert { type: "json" };
+// IMPORTANT: chemin relatif vers data/generated
+import raw from "../../data/generated/motos.json";
 
-const ALL: Moto[] = (data as unknown as Moto[]) ?? [];
+const ALL: Moto[] = (raw as unknown as Moto[]) ?? [];
+
+// Petit garde-fou : si 0 ou trop peu d’entrées, log pour diagnostiquer
+if (typeof window === "undefined") {
+  console.log("[motos] loaded entries:", ALL.length);
+}
 
 export function getAllMotos(): Moto[] {
   return ALL;
@@ -9,6 +15,4 @@ export function getAllMotos(): Moto[] {
 export function findById(id: string): Moto | undefined {
   return ALL.find((m) => m.id === id);
 }
-export function findByBrand(brandSlug: string): Moto[] {
-  return ALL.filter((m) => m.brandSlug === brandSlug);
-}
+


### PR DESCRIPTION
## Summary
- load motos from `data/generated/motos.json`
- show model count and clickable cards on `/motos`
- render specs and debug JSON on `/modeles/[id]`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: next: not found)*
- `npm run typecheck` *(fails: Cannot find module 'node:path' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68af9fd942d4832b8b1a3b43157ec917