### PR TITLE
feat: merge long and wide moto spec ingestion

### DIFF
--- a/scripts/ingest-motos.ts
+++ b/scripts/ingest-motos.ts
@@ -3,296 +3,214 @@ import fs from "fs-extra";
 import path from "node:path";
 import { globby } from "globby";
 import * as XLSX from "xlsx";
-import { z } from "zod";
 
-function slugify(input: string): string {
-  return input
-    .normalize("NFKD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
+type SpecValue = string | number | boolean | null;
+type Specs = Record<string, SpecValue>;
+type Moto = {
+  id: string;
+  brand: string; brandSlug: string;
+  model: string; modelSlug: string;
+  year?: number | null;
+  price?: number | null;
+  category?: string | null;
+  imageUrl?: string | null;
+  specs: Specs;
+  sourceFile: string;
+  sheet?: string | null;
+  createdAt: string;
+};
+
+function slugify(s: string): string {
+  return s.normalize("NFKD").replace(/[\u0300-\u036f]/g,"")
+    .toLowerCase().replace(/[^a-z0-9]+/g,"-").replace(/^-+|-+$/g,"");
 }
-
-function toKey(input: string): string {
-  return slugify(input).replace(/-/g, "_");
+function toKey(h: string): string {
+  return slugify(h).replace(/-/g,"_");
 }
-
-function parseNumber(val: unknown): number | null {
-  if (val == null) return null;
-  if (typeof val === "number" && Number.isFinite(val)) return val;
-  const s = String(val).trim().replace(",", ".");
-  const m = s.match(/-?\d+(\.\d+)?/);
+function num(s: unknown): number | null {
+  if (s == null || s === "") return null;
+  if (typeof s === "number" && Number.isFinite(s)) return s;
+  const m = String(s).replace(",", ".").match(/-?\d+(\.\d+)?/);
   return m ? Number(m[0]) : null;
 }
-
-function parseBoolean(val: unknown): boolean | null {
-  if (val == null) return null;
-  const s = String(val).trim().toLowerCase();
-  if (["yes", "oui", "true", "vrai", "1"].includes(s)) return true;
-  if (["no", "non", "false", "faux", "0"].includes(s)) return false;
+function bool(s: unknown): boolean | null {
+  if (s == null) return null;
+  const v = String(s).trim().toLowerCase();
+  if (["yes","true","1","oui","vrai"].includes(v)) return true;
+  if (["no","false","0","non","faux"].includes(v)) return false;
   return null;
 }
-
-function coerceValue(
-  key: string,
-  raw: unknown,
-): string | number | boolean | null {
-  if (raw == null || raw === "") return null;
-  if (
-    /_?(price|prix|capacity|weight|power|hp|kw|nm|cc|mm|cm|inch|kmh|mph|rpm|size|height|width|length|wheelbase|seat)/.test(
-      key,
-    )
-  ) {
-    const n = parseNumber(raw);
-    if (n !== null) return n;
+// heuristique: nombres pour clés “numériques”
+function coerce(key: string, v: unknown): SpecValue {
+  if (v == null || v === "") return null;
+  if (/_?(price|prix|power|hp|kw|nm|cc|mm|cm|inch|kg|kmh|mph|rpm|capacity|weight|torque|seat|height|width|length|wheelbase)/.test(key)) {
+    const n = num(v); if (n != null) return n;
   }
-  const b = parseBoolean(raw);
-  if (b !== null) return b;
-  return String(raw).trim();
+  const b = bool(v); if (b != null) return b;
+  const s = String(v).trim();
+  // “1103cc” → 1103 si court
+  if (s.length <= 12) {
+    const n2 = num(s); if (n2 != null) return n2;
+  }
+  return s;
 }
 
-const CoreSchema = z.object({
-  brand: z.string().min(1),
-  model: z.string().min(1),
-  year: z.number().int().nullable().optional(),
-  price: z.number().nullable().optional(),
-  category: z.string().nullable().optional(),
-  imageUrl: z.string().url().nullable().optional(),
-});
-
-function sheetRows(sheet: XLSX.WorkSheet): Record<string, unknown>[] {
-  const rows: any[][] = XLSX.utils.sheet_to_json(sheet, {
-    header: 1,
-    defval: null,
-  });
+function readRows(ws: XLSX.WorkSheet): Record<string, unknown>[] {
+  const rows: any[][] = XLSX.utils.sheet_to_json(ws, { header: 1, defval: null });
   if (!rows.length) return [];
   const header = rows[0].map((h: any) => (h == null ? "" : String(h).trim()));
   return rows.slice(1).map((arr) => {
-    const obj: Record<string, unknown> = {};
-    header.forEach((h, i) => {
-      if (!h) return;
-      obj[h] = arr[i] ?? null;
-    });
-    return obj;
+    const o: Record<string, unknown> = {};
+    header.forEach((h, i) => { if (h) o[h] = arr[i] ?? null; });
+    return o;
   });
 }
 
 function pickMainSheet(wb: XLSX.WorkBook): string | null {
   if (!wb.SheetNames.length) return null;
-  const priority = ["models", "modeles", "motos", "data", "sheet1"];
-  const lower = wb.SheetNames.map((n) => n.toLowerCase());
-  for (const p of priority) {
-    const idx = lower.findIndex((n) => n.includes(p));
-    if (idx >= 0) return wb.SheetNames[idx];
+  const prio = ["models","modeles","motos","data","sheet1"];
+  const L = wb.SheetNames.map(n => n.toLowerCase());
+  for (const p of prio) {
+    const i = L.findIndex(n => n.includes(p));
+    if (i >= 0) return wb.SheetNames[i];
   }
-  let best = wb.SheetNames[0],
-    bestCount = -1;
-  for (const name of wb.SheetNames) {
-    const rows = sheetRows(wb.Sheets[name]);
-    if (rows.length > bestCount) {
-      best = name;
-      bestCount = rows.length;
-    }
+  // fallback: plus grande
+  let best = wb.SheetNames[0], count = -1;
+  for (const n of wb.SheetNames) {
+    const c = readRows(wb.Sheets[n]).length;
+    if (c > count) { best = n; count = c; }
   }
   return best;
 }
 
-function mergeSpecs(base: any, extraRows: Record<string, unknown>[]) {
-  const brandKeys = ["brand", "marque", "make"];
-  const modelKeys = ["model", "modèle", "modele"];
-  const pick = (obj: Record<string, unknown>, keys: string[]) => {
-    for (const k of keys) {
-      const v = obj[k] ?? obj[k.toLowerCase()];
-      if (v != null && v !== "") return String(v).trim();
-    }
-    return null;
+type KeyMap = { brand?: string; model?: string; year?: string; price?: string; category?: string; image?: string; key?: string; value?: string; };
+function mapColumns(cols: string[]): KeyMap {
+  const lower = (x: string) => x.toLowerCase();
+  const get = (...names: string[]) => cols.find(c => names.some(n => lower(c).includes(n)));
+  return {
+    brand: get("brand","marque","make"),
+    model: get("model","modèle","modele"),
+    year: get("year","année","annee"),
+    price: get("price","prix"),
+    category: get("category","catégorie","categorie"),
+    image: get("image","imageurl","photo","img"),
+    key: get("key","clé","cle","spec","item","caracteristique","caractéristique"),
+    value: get("value","valeur","val","data"),
   };
-  for (const row of extraRows) {
-    const b = pick(row, brandKeys);
-    const m = pick(row, modelKeys);
-    if (!b || !m) continue;
-    if (slugify(b) === base.brandSlug && slugify(m) === base.modelSlug) {
-      const keyRaw =
-        row["key"] ??
-        row["clé"] ??
-        row["cle"] ??
-        row["spec"] ??
-        row["item"] ??
-        null;
-      const valRaw =
-        row["value"] ?? row["valeur"] ?? row["val"] ?? row["data"] ?? null;
-      if (keyRaw) {
-        const key = toKey(String(keyRaw));
-        base.specs[key] = coerceValue(key, valRaw);
-        continue;
-      }
-      for (const [k, v] of Object.entries(row)) {
-        const lk = k.toLowerCase().trim();
-        if (
-          ["brand", "marque", "make", "model", "modèle", "modele"].includes(lk)
-        )
-          continue;
-        const key = toKey(k);
-        base.specs[key] = coerceValue(key, v);
-      }
-    }
-  }
 }
 
-function buildMotoFromRow(
-  row: Record<string, unknown>,
-  sourceFile: string,
-  sheetName: string | null,
-) {
-  const map = new Map<string, unknown>();
-  for (const [k, v] of Object.entries(row)) map.set(k.toLowerCase(), v);
-
-  const get = (...keys: string[]) => {
-    for (const k of keys) {
-      const v = map.get(k);
-      if (v != null && v !== "") return v;
-    }
-    return null;
-  };
-
-  const brand = String(get("brand", "marque", "make") ?? "").trim();
-  const model = String(get("model", "modèle", "modele") ?? "").trim();
-  if (!brand || !model) return null;
-
-  const year = parseNumber(get("year", "année", "annee"));
-  const price = parseNumber(get("price", "prix"));
-  const category = get("category", "catégorie", "categorie");
-  const imageUrl = get("image", "imageurl", "photo", "img");
-
-  const specs: Record<string, unknown> = {};
-  for (const [rawKey, rawVal] of Object.entries(row)) {
-    if (!rawKey || rawVal == null || rawVal === "") continue;
-    const k = rawKey.toLowerCase().trim();
-    if (
-      [
-        "brand",
-        "marque",
-        "make",
-        "model",
-        "modèle",
-        "modele",
-        "year",
-        "année",
-        "annee",
-        "price",
-        "prix",
-        "category",
-        "catégorie",
-        "categorie",
-        "image",
-        "imageurl",
-        "photo",
-        "img",
-      ].includes(k)
-    )
-      continue;
-    const key = toKey(rawKey);
-    specs[key] = coerceValue(key, rawVal);
-  }
-
-  const brandSlug = slugify(brand);
-  const modelSlug = slugify(model);
-  const id = [brandSlug, modelSlug, year ?? ""].filter(Boolean).join("-");
-
-  const core = {
-    brand,
-    model,
-    year: year ?? null,
-    price: price ?? null,
-    category: category ? String(category) : null,
-    imageUrl: imageUrl ? String(imageUrl) : null,
-  };
-  const ok = CoreSchema.safeParse(core);
-  if (!ok.success) return null;
-
-  return {
-    id,
-    brand,
-    brandSlug,
-    model,
-    modelSlug,
-    year: ok.data.year ?? null,
-    price: ok.data.price ?? null,
-    category: ok.data.category ?? null,
-    imageUrl: ok.data.imageUrl ?? null,
-    specs: specs as Record<string, string | number | boolean | null>,
-    sourceFile: path.basename(sourceFile),
-    sheet: sheetName,
-    createdAt: new Date().toISOString(),
-  };
+function idFor(brand: string, model: string, year: number | null): string {
+  return [slugify(brand), slugify(model), year ?? ""].filter(Boolean).join("-");
 }
 
 async function main() {
-  const inputDir = path.resolve("data/excel");
+  const inDir = path.resolve("data/excel");
   const outDir = path.resolve("data/generated");
   await fs.ensureDir(outDir);
 
-  const files = await globby(["*.xlsx", "*.xls"], {
-    cwd: inputDir,
-    absolute: true,
-  });
+  const files = await globby(["*.xlsx","*.xls"], { cwd: inDir, absolute: true });
   if (!files.length) {
-    console.log(
-      "Aucun Excel trouvé dans data/excel/. Place un fichier puis relance.",
-    );
+    console.log("Aucun Excel dans data/excel/");
     return;
   }
 
-  const all: any[] = [];
+  // Registre par id
+  const byId = new Map<string, Moto>();
+
   for (const file of files) {
     const wb = XLSX.readFile(file);
-    const best = pickMainSheet(wb);
-    if (!best) continue;
-    const rows = sheetRows(wb.Sheets[best]);
+    const main = pickMainSheet(wb);
+    const sheets = wb.SheetNames;
+    for (const name of sheets) {
+      const ws = wb.Sheets[name];
+      const rows = readRows(ws);
+      if (!rows.length) continue;
 
-    // specs additionnelles si des onglets 'Specs*'
-    const extra: Record<string, unknown>[] = [];
-    wb.SheetNames.forEach((n) => {
-      if (/^specs/i.test(n)) extra.push(...sheetRows(wb.Sheets[n]));
-    });
+      const cols = Object.keys(rows[0] ?? {});
+      const m = mapColumns(cols);
 
-    for (const row of rows) {
-      const moto = buildMotoFromRow(row, file, best);
-      if (!moto) continue;
-      if (extra.length) mergeSpecs(moto, extra);
-      all.push(moto);
+      // MODE LONG (clé/valeur) si on a brand+model+(key,value)
+      const isLong = !!(m.brand && m.model && m.key && m.value);
+
+      for (const row of rows) {
+        const brand = String(row[m.brand ?? ""] ?? "").trim();
+        const model = String(row[m.model ?? ""] ?? "").trim();
+        if (!brand || !model) continue;
+
+        const year = m.year ? num(row[m.year]) : null;
+        const price = m.price ? num(row[m.price]) : null;
+        const category = m.category ? String(row[m.category] ?? "").trim() || null : null;
+        const imageUrl = m.image ? String(row[m.image] ?? "").trim() || null : null;
+
+        const _id = idFor(brand, model, year ?? null);
+        if (!byId.has(_id)) {
+          byId.set(_id, {
+            id: _id,
+            brand, brandSlug: slugify(brand),
+            model, modelSlug: slugify(model),
+            year: year ?? null,
+            price: price ?? null,
+            category,
+            imageUrl,
+            specs: {},
+            sourceFile: path.basename(file),
+            sheet: name,
+            createdAt: new Date().toISOString(),
+          });
+        }
+        const moto = byId.get(_id)!;
+
+        if (isLong) {
+          // ex: Brand | Model | Year | Key | Value (plusieurs lignes par modèle)
+          const kRaw = String(row[m.key!]).trim();
+          const vRaw = row[m.value!];
+          if (kRaw) {
+            const k = toKey(kRaw);
+            moto.specs[k] = coerce(k, vRaw);
+          }
+        } else {
+          // MODE LARGE: toutes les colonnes sauf cœur → specs
+          for (const [col, v] of Object.entries(row)) {
+            if (!col || v == null || v === "") continue;
+            const lc = col.toLowerCase().trim();
+            const isCore = [m.brand, m.model, m.year, m.price, m.category, m.image]
+              .filter(Boolean)
+              .some((c) => c && c.toLowerCase().trim() === lc);
+            if (isCore) continue;
+            const k = toKey(col);
+            moto.specs[k] = coerce(k, v);
+          }
+        }
+
+        // garde les infos “cœur” non vides (si vues sur une autre ligne/feuille)
+        if (price != null) moto.price = price;
+        if (category && !moto.category) moto.category = category;
+        if (imageUrl && !moto.imageUrl) moto.imageUrl = imageUrl;
+      }
     }
   }
 
-  all.sort((a, b) => {
-    if (a.brandSlug !== b.brandSlug)
-      return a.brandSlug.localeCompare(b.brandSlug);
-    if (a.modelSlug !== b.modelSlug)
-      return a.modelSlug.localeCompare(b.modelSlug);
+  // Sort et écriture
+  const all = Array.from(byId.values()).sort((a, b) => {
+    if (a.brandSlug !== b.brandSlug) return a.brandSlug.localeCompare(b.brandSlug);
+    if (a.modelSlug !== b.modelSlug) return a.modelSlug.localeCompare(b.modelSlug);
     return (b.year ?? 0) - (a.year ?? 0);
   });
 
-  await fs.writeJSON(path.join(outDir, "motos.json"), all, { spaces: 2 });
+  await fs.writeJson(path.join(outDir, "motos.json"), all, { spaces: 2 });
 
   // par marque
-  const byBrand = new Map<string, any[]>();
+  const per = new Map<string, Moto[]>();
   for (const m of all) {
-    if (!byBrand.has(m.brandSlug)) byBrand.set(m.brandSlug, []);
-    byBrand.get(m.brandSlug)!.push(m);
+    if (!per.has(m.brandSlug)) per.set(m.brandSlug, []);
+    per.get(m.brandSlug)!.push(m);
   }
-  for (const [slug, list] of byBrand) {
-    await fs.writeJSON(path.join(outDir, `motos_${slug}.json`), list, {
-      spaces: 2,
-    });
+  for (const [slug, list] of per) {
+    await fs.writeJson(path.join(outDir, `motos_${slug}.json`), list, { spaces: 2 });
   }
 
-  console.log(
-    `✅ Ingestion: ${all.length} modèles → data/generated/motos.json (+ ${byBrand.size} fichiers par marque)`,
-  );
+  console.log(`✅ Ingestion v2: ${all.length} modèles, specs fusionnées (LARGE+LONG) → data/generated/`);
 }
 
-main().catch((e) => {
-  console.error("❌ Erreur ingestion:", e);
-  process.exit(1);
-});
+main().catch((e) => { console.error("❌ Erreur ingestion v2:", e); process.exit(1); });
+

--- a/scripts/ingest-motos.ts
+++ b/scripts/ingest-motos.ts
@@ -197,7 +197,7 @@ async function main() {
     return (b.year ?? 0) - (a.year ?? 0);
   });
 
-  await fs.writeJson(path.join(outDir, "motos.json"), all, { spaces: 2 });
+  await fs.writeJSON(path.join(outDir, "motos.json"), all, { spaces: 2 });
 
   // par marque
   const per = new Map<string, Moto[]>();
@@ -206,7 +206,7 @@ async function main() {
     per.get(m.brandSlug)!.push(m);
   }
   for (const [slug, list] of per) {
-    await fs.writeJson(path.join(outDir, `motos_${slug}.json`), list, { spaces: 2 });
+    await fs.writeJSON(path.join(outDir, `motos_${slug}.json`), list, { spaces: 2 });
   }
 
   console.log(`✅ Ingestion v2: ${all.length} modèles, specs fusionnées (LARGE+LONG) → data/generated/`);


### PR DESCRIPTION
## Summary
- replace ingest-motos script to support both long key-value and wide column Excel formats
- normalize spec keys, coerce numbers/booleans, and export per-brand JSON files

## Testing
- `npm run ingest:motos` *(fails: tsx not found)*
- `npm install` *(fails: 403 Forbidden fetching fs-extra)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afa2a3d7dc832babbd65768864b6d7