### PR TITLE
feat: add markdown-based magazine

### DIFF
--- a/content/mag/actu-salon-tunis.md
+++ b/content/mag/actu-salon-tunis.md
@@ -1,0 +1,7 @@
+---
+title: "Actu: Salon de la moto Tunis"
+date: "2025-08-05"
+excerpt: "Récap des nouveautés phares."
+tags: ["actu","salon"]
+---
+Les nouveautés marquantes, tendances 2025… *Texte de démonstration*.

--- a/content/mag/essai-panigale-v4.md
+++ b/content/mag/essai-panigale-v4.md
@@ -1,0 +1,7 @@
+---
+title: "Essai Ducati Panigale V4"
+date: "2025-08-20"
+excerpt: "Prise en main de la supersport italienne."
+tags: ["essai","ducati"]
+---
+Premières sensations, ergonomie, moteur, châssis… *Texte de démonstration*.

--- a/content/mag/guide-achat-a2.md
+++ b/content/mag/guide-achat-a2.md
@@ -1,0 +1,7 @@
+---
+title: "Guide d’achat: Permis A2, que choisir ?"
+date: "2025-08-12"
+excerpt: "Nos conseils pour bien débuter."
+tags: ["guide","A2","débutant"]
+---
+Les critères essentiels, budget, puissance, entretien… *Texte de démonstration*.

--- a/package.json
+++ b/package.json
@@ -73,7 +73,9 @@
     "vaul": "^0.9.9",
     "xlsx": "^0.18.5",
     "zod": "^3.23.8",
-    "globby": "^14.0.1"
+    "globby": "^14.0.1",
+    "gray-matter": "^4.0.3",
+    "marked": "^12.0.2"
   },
   "devDependencies": {
     "prettier": "^3.3.3",

--- a/src/app/mag/[slug]/not-found.tsx
+++ b/src/app/mag/[slug]/not-found.tsx
@@ -1,0 +1,7 @@
+export default function NotFound() {
+  return (
+    <main className="mx-auto max-w-3xl px-4 py-10">
+      <p>Article introuvable.</p>
+    </main>
+  );
+}

--- a/src/app/mag/[slug]/page.tsx
+++ b/src/app/mag/[slug]/page.tsx
@@ -1,0 +1,17 @@
+import { notFound } from "next/navigation";
+import { getArticle } from "@/src/lib/articles";
+
+export const dynamic = "force-static";
+
+export default function ArticlePage({ params }: { params: { slug: string } }) {
+  const a = getArticle(params.slug);
+  if (!a) return notFound();
+  return (
+    <main className="mx-auto max-w-3xl px-4 py-10">
+      <a href="/mag" className="underline text-sm text-gray-500">← Magazine</a>
+      <h1 className="text-3xl font-semibold mt-2 mb-2">{a.title}</h1>
+      <p className="text-sm text-gray-500 mb-6">{a.date}</p>
+      <article className="prose" dangerouslySetInnerHTML={{ __html: a.html }} />
+    </main>
+  );
+}

--- a/src/app/mag/page.tsx
+++ b/src/app/mag/page.tsx
@@ -1,8 +1,28 @@
+import Link from "next/link";
+import { listArticles } from "@/src/lib/articles";
+
+export const dynamic = "force-static";
+
 export default function MagPage() {
+  const articles = listArticles();
   return (
-    <div className="p-8">
-      <h1 className="text-3xl font-bold text-fg">Magazine</h1>
-      <p className="mt-4 text-muted">Les articles arriveront prochainement.</p>
-    </div>
+    <main className="mx-auto max-w-5xl px-4 py-10">
+      <h1 className="text-3xl font-semibold mb-6">Magazine</h1>
+      {articles.length === 0 ? (
+        <p>Aucun article pour l’instant.</p>
+      ) : (
+        <ul className="grid gap-6 sm:grid-cols-2">
+          {articles.map(a => (
+            <li key={a.slug} className="rounded-xl border p-4 hover:shadow">
+              <h2 className="text-xl font-medium mb-1">
+                <Link href={`/mag/${a.slug}`}>{a.title}</Link>
+              </h2>
+              <p className="text-sm text-gray-500 mb-2">{a.date}</p>
+              {a.excerpt && <p className="line-clamp-3">{a.excerpt}</p>}
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
   );
 }

--- a/src/lib/articles.ts
+++ b/src/lib/articles.ts
@@ -1,0 +1,46 @@
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+import { marked } from "marked";
+
+const DIR = path.join(process.cwd(), "content", "mag");
+
+export type ArticleMeta = {
+  slug: string; title: string; date: string;
+  excerpt?: string; cover?: string; tags?: string[];
+};
+export type Article = ArticleMeta & { html: string };
+
+export function listArticles(): ArticleMeta[] {
+  if (!fs.existsSync(DIR)) return [];
+  const files = fs.readdirSync(DIR).filter(f => f.endsWith(".md"));
+  const metas = files.map(file => {
+    const slug = file.replace(/\.md$/, "");
+    const { data } = matter(fs.readFileSync(path.join(DIR, file), "utf8"));
+    return {
+      slug,
+      title: data.title ?? slug,
+      date: data.date ?? "",
+      excerpt: data.excerpt ?? "",
+      cover: data.cover ?? "",
+      tags: Array.isArray(data.tags) ? data.tags : []
+    } as ArticleMeta;
+  });
+  return metas.sort((a,b) => (b.date || "").localeCompare(a.date || ""));
+}
+
+export function getArticle(slug: string): Article | null {
+  const file = path.join(DIR, `${slug}.md`);
+  if (!fs.existsSync(file)) return null;
+  const { data, content } = matter(fs.readFileSync(file, "utf8"));
+  const html = marked.parse(content) as string;
+  return {
+    slug,
+    title: data.title ?? slug,
+    date: data.date ?? "",
+    excerpt: data.excerpt ?? "",
+    cover: data.cover ?? "",
+    tags: Array.isArray(data.tags) ? data.tags : [],
+    html
+  };
+}


### PR DESCRIPTION
## Summary
- add gray-matter and marked dependencies
- implement markdown-based magazine with listing and article pages
- seed magazine with three example articles

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/gray-matter)*
- `npm run lint` *(fails: next: not found)*
- `npm run build` *(fails: next: not found)*
- `npm run typecheck` *(fails: Cannot find module 'node:fs/promises' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c675fe00832ba879c9b1198d424a