### PR TITLE
feat: auto-ingest motos data

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eslint": "8.49.0",
     "eslint-config-next": "13.5.1",
     "framer-motion": "^12.23.12",
+    "fs-extra": "^11.1.1",
     "input-otp": "^1.2.4",
     "lucide-react": "^0.446.0",
     "next": "13.5.1",

--- a/src/app/debug/motos/page.tsx
+++ b/src/app/debug/motos/page.tsx
@@ -1,0 +1,18 @@
+import { loadAllMotos } from "../../../lib/motos.server";
+
+export const dynamic = "force-static";
+
+export default function DebugMotos() {
+  const all = loadAllMotos();
+  const first = all[0];
+  return (
+    <main className="mx-auto max-w-4xl px-4 py-8">
+      <h1 className="text-2xl font-semibold mb-4">Debug Motos</h1>
+      <p className="text-sm text-gray-500 mb-4">{all.length} modèles chargés</p>
+      <pre className="rounded bg-black/80 p-3 text-xs text-white overflow-auto">
+{JSON.stringify(first ?? {}, null, 2)}
+      </pre>
+    </main>
+  );
+}
+

--- a/src/app/modeles/[id]/page.tsx
+++ b/src/app/modeles/[id]/page.tsx
@@ -1,16 +1,12 @@
 import { notFound } from "next/navigation";
-import { findById } from "../../../lib/motos";
+import { findById } from "../../../lib/motos.server";
 import SpecsTable from "../../../components/SpecsTable";
 
-function Row({ label, value }: { label: string; value?: string | number | null }) {
-  if (value == null || value === "") return null;
-  return <p><span className="text-gray-500">{label}:</span> {value}</p>;
-}
+export const dynamic = "force-static";
 
 export default function ModelePage({ params }: { params: { id: string } }) {
   const moto = findById(params.id);
   if (!moto) return notFound();
-
   const { brand, model, year, price, category, imageUrl, specs } = moto;
   const specCount = specs ? Object.keys(specs).length : 0;
 
@@ -19,33 +15,21 @@ export default function ModelePage({ params }: { params: { id: string } }) {
       <nav className="mb-4 text-sm text-gray-500">
         <a href="/motos" className="underline">← Retour aux motos</a>
       </nav>
-
       <header className="mb-6">
         <h1 className="text-3xl font-semibold">
           {brand} {model}{year ? ` · ${year}` : ""}
         </h1>
         <div className="mt-2 space-y-1">
-          <Row label="Prix" value={price ?? null} />
-          <Row label="Catégorie" value={category ?? null} />
+          {price != null && <p><span className="text-gray-500">Prix:</span> {price}</p>}
+          {category && <p><span className="text-gray-500">Catégorie:</span> {category}</p>}
         </div>
-        {imageUrl ? (
-          <img src={imageUrl} alt={`${brand} ${model}`} className="mt-4 max-h-72 rounded-lg object-cover" />
-        ) : null}
+        {imageUrl ? <img src={imageUrl} alt={`${brand} ${model}`} className="mt-4 max-h-72 rounded-lg object-cover" /> : null}
         <p className="text-sm text-gray-500 mt-2">{specCount} caractéristiques techniques</p>
       </header>
-
       <section className="space-y-3">
         <h2 className="text-xl font-medium">Caractéristiques techniques</h2>
         <SpecsTable specs={specs || {}} />
       </section>
-
-      {/* Debug dev : retire après validation */}
-      <details className="mt-6">
-        <summary className="cursor-pointer text-sm text-gray-500">Voir JSON brut (debug)</summary>
-        <pre className="mt-2 overflow-auto rounded bg-black/80 p-3 text-xs text-white">
-{JSON.stringify(moto, null, 2)}
-        </pre>
-      </details>
     </main>
   );
 }

--- a/src/app/motos/page.tsx
+++ b/src/app/motos/page.tsx
@@ -1,36 +1,19 @@
-"use client";
 import Link from "next/link";
-import { useMemo, useState } from "react";
-import { getAllMotos } from "../../lib/motos";
+import { loadAllMotos } from "../../lib/motos.server";
+
+export const dynamic = "force-static";
 
 export default function MotosPage() {
-  const [q, setQ] = useState("");
-  const all = useMemo(() => getAllMotos(), []);
-  const list = useMemo(() => {
-    const s = q.toLowerCase().trim();
-    if (!s) return all;
-    return all.filter(m =>
-      m.brand.toLowerCase().includes(s) ||
-      m.model.toLowerCase().includes(s)
-    );
-  }, [q, all]);
-
+  const all = loadAllMotos();
   return (
     <main className="mx-auto max-w-6xl px-4 py-8">
-      <h1 className="text-3xl font-semibold mb-2">Motos neuves</h1>
-      <p className="text-sm text-gray-500 mb-4">({all.length} modèles chargés)</p>
-      <input
-        value={q}
-        onChange={(e) => setQ(e.target.value)}
-        placeholder="Rechercher marque ou modèle…"
-        className="w-full mb-6 rounded-md border px-3 py-2"
-        aria-label="Recherche"
-      />
-      {list.length === 0 ? (
-        <p>Aucun modèle trouvé.</p>
+      <h1 className="text-3xl font-semibold mb-1">Motos neuves</h1>
+      <p className="text-sm text-gray-500 mb-6">({all.length} modèles chargés)</p>
+      {all.length === 0 ? (
+        <p>Aucun modèle trouvé. Vérifie data/excel/ et/ou la génération du JSON.</p>
       ) : (
         <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {list.map((m) => (
+          {all.map((m) => (
             <li key={m.id} className="rounded-xl border p-4 hover:shadow">
               <Link href={`/modeles/${m.id}`} className="block">
                 <div className="text-sm text-gray-500">{m.brand}</div>

--- a/src/lib/motos.server.ts
+++ b/src/lib/motos.server.ts
@@ -1,0 +1,211 @@
+import fs from "fs";
+import path from "path";
+import * as XLSX from "xlsx";
+
+export type SpecValue = string | number | boolean | null;
+export type Specs = Record<string, SpecValue>;
+export type Moto = {
+  id: string;
+  brand: string; brandSlug: string;
+  model: string; modelSlug: string;
+  year?: number | null;
+  price?: number | null;
+  category?: string | null;
+  imageUrl?: string | null;
+  specs: Specs;
+  sourceFile?: string; sheet?: string | null;
+  createdAt?: string;
+};
+
+const ROOT = process.cwd();
+
+function slugify(s: string) {
+  return s.normalize("NFKD").replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+function toKey(...parts: (string|number|null|undefined)[]) {
+  return parts
+    .filter(Boolean)
+    .map(p => String(p).trim().toLowerCase()
+      .normalize("NFKD").replace(/[\u0300-\u036f]/g,"")
+      .replace(/[^a-z0-9]+/g,"_"))
+    .join("_");
+}
+function num(v: unknown): number | null {
+  if (v == null || v === "") return null;
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  const m = String(v).replace(/\s/g,"").replace(",",".").match(/-?\d+(\.\d+)?/);
+  return m ? Number(m[0]) : null;
+}
+function bool(v: unknown): boolean | null {
+  const s = String(v ?? "").trim().toLowerCase();
+  if (!s) return null;
+  if (["yes","true","1","oui","vrai"].includes(s)) return true;
+  if (["no","false","0","non","faux"].includes(s)) return false;
+  return null;
+}
+function coerce(key: string, v: unknown): SpecValue {
+  if (v == null || v === "") return null;
+  if (/_?(price|prix|hp|kw|nm|cc|mm|cm|inch|kg|kmh|mph|rpm|capacity|weight|torque|seat|height|width|length|wheelbase|tank)/.test(key)) {
+    const n = num(v); if (n != null) return n;
+  }
+  const b = bool(v); if (b != null) return b;
+  const s = String(v).trim();
+  if (s.length <= 14) { const n2 = num(s); if (n2 != null) return n2; }
+  return s;
+}
+
+function safeReadJSON(...parts: string[]) {
+  try {
+    const p = path.join(ROOT, ...parts);
+    if (fs.existsSync(p)) {
+      const data = JSON.parse(fs.readFileSync(p, "utf8"));
+      if (Array.isArray(data) && data.length) return data as Moto[];
+    }
+  } catch {}
+  return null;
+}
+
+function makeId(brand: string, model: string, year: number | null) {
+  return [slugify(brand), slugify(model), year ?? ""].filter(Boolean).join("-");
+}
+
+function ingestPivotInto(all: Moto[], arr: any[][], fileName: string, sheetName: string) {
+  const header = (arr[0] || []).map((h:any)=>String(h??"").trim());
+  const idxCat = 0, idxSub = 1;
+  // pour chaque colonne modèle
+  for (let col = 2; col < header.length; col++) {
+    const colName = header[col]; if (!colName) continue;
+    let brand = "", model = "", category: string|null = null;
+    let year: number|null = null, price: number|null = null;
+
+    for (let r = 1; r < arr.length; r++) {
+      const cat = String(arr[r][idxCat] ?? "").trim();
+      const sub = String(arr[r][idxSub] ?? "").trim();
+      const val = arr[r][col];
+      if (cat === "Informations générales") {
+        if (sub === "Marque") brand = String(val ?? "").trim();
+        else if (sub === "Modèle") model = String(val ?? "").trim();
+        else if (sub === "Année") { const n = num(val); if (n != null) year = n; }
+        else if (sub === "Prix (TND)") { const n = num(val); if (n != null) price = n; }
+        else if (sub === "Segment" || sub === "Catégorie") category = String(val ?? "").trim() || null;
+      }
+    }
+    if (!brand || !model) continue;
+
+    const id = makeId(brand, model, year);
+    let moto = all.find(m => m.id === id);
+    if (!moto) {
+      moto = {
+        id, brand, brandSlug: slugify(brand),
+        model, modelSlug: slugify(model),
+        year, price, category, imageUrl: null,
+        specs: {}, sourceFile: fileName, sheet: sheetName,
+        createdAt: new Date().toISOString(),
+      };
+      all.push(moto);
+    }
+    for (let r = 1; r < arr.length; r++) {
+      const cat = String(arr[r][idxCat] ?? "").trim();
+      const sub = String(arr[r][idxSub] ?? "").trim();
+      const val = arr[r][col];
+      if (cat === "Informations générales" && ["Marque","Modèle","Année","Prix (TND)","Segment","Catégorie"].includes(sub)) continue;
+      const key = toKey(cat, sub);
+      moto.specs[key] = coerce(key, val);
+    }
+  }
+}
+
+function ingestLargeInto(all: Moto[], rows: Record<string, unknown>[], fileName: string, sheetName: string) {
+  if (!rows.length) return;
+  const cols = Object.keys(rows[0]);
+  const lower = (s:string)=> s.toLowerCase();
+  const get = (...names:string[]) => cols.find(c => names.some(n => lower(c).includes(n)));
+  const m = {
+    brand: get("brand","marque","make"),
+    model: get("model","modèle","modele"),
+    year: get("year","année","annee"),
+    price: get("price","prix"),
+    category: get("category","catégorie","categorie"),
+    image: get("image","imageurl","photo","img"),
+  };
+  for (const row of rows) {
+    const brand = String(row[m.brand ?? ""] ?? "").trim();
+    const model = String(row[m.model ?? ""] ?? "").trim();
+    if (!brand || !model) continue;
+    const year = m.year ? num(row[m.year as string]) : null;
+    const price = m.price ? num(row[m.price as string]) : null;
+    const category = m.category ? (String(row[m.category as string] ?? "").trim() || null) : null;
+    const imageUrl = m.image ? (String(row[m.image as string] ?? "").trim() || null) : null;
+
+    const id = makeId(brand, model, year);
+    let moto = all.find(m => m.id === id);
+    if (!moto) {
+      moto = {
+        id, brand, brandSlug: slugify(brand),
+        model, modelSlug: slugify(model),
+        year, price, category, imageUrl, specs: {},
+        sourceFile: fileName, sheet: sheetName, createdAt: new Date().toISOString()
+      };
+      all.push(moto);
+    }
+    for (const [col, v] of Object.entries(row)) {
+      if (!col || v == null || v === "") continue;
+      const lc = col.toLowerCase().trim();
+      const isCore = [m.brand,m.model,m.year,m.price,m.category,m.image]
+        .filter(Boolean).some(c => c && c.toLowerCase().trim() === lc);
+      if (isCore) continue;
+      const key = toKey(col);
+      moto.specs[key] = coerce(key, v);
+    }
+  }
+}
+
+export function loadAllMotos(): Moto[] {
+  // 1) Essayer le JSON généré
+  const fromJson = safeReadJSON("data","generated","motos.json");
+  if (fromJson) return fromJson;
+
+  // 2) Fallback: lire l'Excel et générer le JSON
+  const excelDir = path.join(ROOT, "data", "excel");
+  const files = fs.existsSync(excelDir)
+    ? fs.readdirSync(excelDir).filter(f => /\.(xlsx|xls)$/i.test(f))
+    : [];
+  const all: Moto[] = [];
+  for (const file of files) {
+    const full = path.join(excelDir, file);
+    const wb = XLSX.readFile(full);
+    for (const sheetName of wb.SheetNames) {
+      const ws = wb.Sheets[sheetName];
+      const arr = XLSX.utils.sheet_to_json(ws, { header: 1, defval: null }) as any[][];
+      if (!arr.length) continue;
+      const header = (arr[0]||[]).map((h:any)=>String(h??"").trim());
+      const isPivot = header.length >= 4
+        && header[0].toLowerCase().normalize("NFKD").replace(/[\u0300-\u036f]/g,"")==="categorie"
+        && header[1].toLowerCase().includes("sous");
+      if (isPivot) {
+        ingestPivotInto(all, arr, path.basename(file), sheetName);
+      } else {
+        const rows = XLSX.utils.sheet_to_json(ws, { defval: null }) as Record<string, unknown>[];
+        ingestLargeInto(all, rows, path.basename(file), sheetName);
+      }
+    }
+  }
+  // écrire le JSON pour les prochains builds
+  if (all.length) {
+    const outDir = path.join(ROOT, "data", "generated");
+    fs.mkdirSync(outDir, { recursive: true });
+    fs.writeFileSync(path.join(outDir, "motos.json"), JSON.stringify(all, null, 2), "utf8");
+  }
+  // trier
+  return all.sort((a,b)=>{
+    if (a.brandSlug !== b.brandSlug) return a.brandSlug.localeCompare(b.brandSlug);
+    if (a.modelSlug !== b.modelSlug) return a.modelSlug.localeCompare(b.modelSlug);
+    return (b.year ?? 0) - (a.year ?? 0);
+  });
+}
+
+export function findById(id: string): Moto | undefined {
+  return loadAllMotos().find(m => m.id === id);
+}
+


### PR DESCRIPTION
## Summary
- add `fs-extra` dependency
- add server utility to load or generate motos from JSON/Excel
- render static motos listing, detail and debug pages using new data loader

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c8ed9c6c832babf32d01c187b7ff