### PR TITLE
feat: use dark text in spec fields

### DIFF
--- a/src/components/moto/SpecItemRow.tsx
+++ b/src/components/moto/SpecItemRow.tsx
@@ -17,7 +17,7 @@ export default function SpecItemRow({ label, value }: SpecItemRowProps) {
         : [String(value)];
   return (
     <li className="flex items-center justify-between py-1">
-      <span className="text-sm text-gray-900">{label}</span>
+      <span className="text-sm text-fg">{label}</span>
       <div className="flex flex-wrap justify-end gap-1">
         {parts.length > 1 ? (
           parts.map((p) => (
@@ -26,7 +26,7 @@ export default function SpecItemRow({ label, value }: SpecItemRowProps) {
             </Badge>
           ))
         ) : (
-          <span className="text-sm text-gray-900">{parts[0]}</span>
+          <span className="text-sm text-fg">{parts[0]}</span>
         )}
       </div>
     </li>

--- a/src/components/moto/SpecsFamilies.tsx
+++ b/src/components/moto/SpecsFamilies.tsx
@@ -14,7 +14,7 @@ export default function SpecsFamilies({ families }: SpecsFamiliesProps) {
         if (!items.length) return null;
         return (
           <section key={family.group}>
-            <h3 className="mb-2 text-lg font-semibold text-gray-900">{family.group}</h3>
+            <h3 className="mb-2 text-lg font-semibold text-fg">{family.group}</h3>
             <ul className="space-y-1">
               {items.map((it) => (
                 <SpecItemRow key={it.label} label={it.label} value={it.value} />


### PR DESCRIPTION
## Summary
- darken spec group headers for better readability
- darken spec labels and single values

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm run typecheck` *(fails: Cannot find module 'node:fs/promises' or its corresponding type declarations.)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ca8bc14c832b8e4b4e09ad65f261