### PR TITLE
Assombrir les badges des caractéristiques

### DIFF
--- a/src/components/moto/SpecItemRow.tsx
+++ b/src/components/moto/SpecItemRow.tsx
@@ -21,7 +21,11 @@ export default function SpecItemRow({ label, value }: SpecItemRowProps) {
       <div className="flex flex-wrap justify-end gap-1">
         {parts.length > 1 ? (
           parts.map((p) => (
-            <Badge key={p} variant="secondary" className="bg-accent text-fg">
+            <Badge
+              key={p}
+              variant="outline"
+              className="border-none bg-[#132E35] text-fg"
+            >
               {p}
             </Badge>
           ))


### PR DESCRIPTION
## Summary
- Harmonise les badges des spécifications moto avec la couleur de fond (#132E35)

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: 403 Forbidden from registry)*
- `npm run typecheck` *(fails: tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ce091ae4832b890983b30efa48ea