### PR TITLE
feat: refresh primary color and specs styling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,6 +9,21 @@
   body {
     @apply bg-bg text-fg;
   }
+  a {
+    color: var(--primary-color);
+  }
+  a:hover,
+  a:focus {
+    color: var(--primary-color);
+  }
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    color: var(--primary-color);
+  }
 }
 
 @layer base {
@@ -19,8 +34,10 @@
     --card-foreground: 175 179 183; /* #AFB3B7 */
     --popover: 19 46 53; /* #132E35 */
     --popover-foreground: 175 179 183; /* #AFB3B7 */
-    --primary: 45 74 83; /* #2D4A53 */
-    --primary-foreground: 175 179 183; /* #AFB3B7 */
+    --primary-color: 175 179 183; /* #AFB3B7 */
+    --characteristics-bg: 19 46 53; /* #132E35 */
+    --primary: var(--primary-color);
+    --primary-foreground: var(--characteristics-bg);
     --secondary: 90 99 106; /* #5A636A */
     --secondary-foreground: 175 179 183; /* #AFB3B7 */
     --muted: 90 99 106; /* #5A636A */

--- a/src/components/moto/SpecItemRow.tsx
+++ b/src/components/moto/SpecItemRow.tsx
@@ -16,17 +16,13 @@ export default function SpecItemRow({ label, value }: SpecItemRowProps) {
         ? [value ? 'Oui' : 'Non']
         : [String(value)];
   return (
-    <li className="flex items-center justify-between py-1">
-      <span className="text-sm text-fg">{label}</span>
+    <li className="flex items-center justify-between py-1 px-2 bg-[var(--characteristics-bg)] text-white">
+      <span className="text-sm">{label}</span>
       <div className="flex flex-wrap justify-end gap-1">
         {parts.length > 1 ? (
-          parts.map((p) => (
-            <Badge key={p} variant="secondary" className="bg-accent text-fg">
-              {p}
-            </Badge>
-          ))
+          parts.map((p) => <Badge key={p}>{p}</Badge>)
         ) : (
-          <span className="text-sm text-fg">{parts[0]}</span>
+          <span className="text-sm">{parts[0]}</span>
         )}
       </div>
     </li>

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -50,7 +50,10 @@ const BreadcrumbLink = React.forwardRef<
   return (
     <Comp
       ref={ref}
-      className={cn('transition-colors hover:text-foreground', className)}
+      className={cn(
+        'text-primary transition-colors hover:opacity-80 focus:opacity-80',
+        className
+      )}
       {...props}
     />
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -32,12 +32,12 @@ const config: Config = {
         },
         // Theme colors
         bg: '#0D1F23',
-        fg: '#AFB3B7',
+        fg: 'rgb(var(--primary-color) / <alpha-value>)',
         surface: '#132E35',
 
         // shadcn/ui compatible colors
         background: '#0D1F23',
-        foreground: '#AFB3B7',
+        foreground: 'rgb(var(--primary-color) / <alpha-value>)',
 
         card: {
           DEFAULT: '#132E35',
@@ -48,8 +48,8 @@ const config: Config = {
           foreground: '#AFB3B7',
         },
         primary: {
-          DEFAULT: '#2D4A53',
-          foreground: '#AFB3B7',
+          DEFAULT: 'rgb(var(--primary-color) / <alpha-value>)',
+          foreground: 'rgb(var(--characteristics-bg) / <alpha-value>)',
         },
         secondary: {
           DEFAULT: '#5A636A',


### PR DESCRIPTION
## Summary
- add CSS variables for primary site color and specs background
- style moto characteristics rows with dark background and white text
- apply new primary color to links and theme config

## Testing
- `npm run lint` *(fails: next: not found)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d158cbc4832bb1e7f0184cd58a3f