### PR TITLE
style: update specs table colors

### DIFF
--- a/src/components/SpecsTable.tsx
+++ b/src/components/SpecsTable.tsx
@@ -6,10 +6,13 @@ export default function SpecsTable({ specs }: Props) {
   const entries = Object.entries(specs || {});
   if (!entries.length) return <p>Pas de caractéristiques disponibles.</p>;
   return (
-    <table className="w-full border-separate border-spacing-y-1">
+    <table className="w-full border-collapse">
       <tbody>
         {entries.map(([k, v]) => (
-          <tr key={k} className="bg-white/60">
+          <tr
+            key={k}
+            className="bg-[#132E35] text-white border-b border-[#AFB3B7] last:border-b-0"
+          >
             <th className="text-left font-medium pr-4 py-2">{humanize(k)}</th>
             <td className="py-2">{String(v ?? "—")}</td>
           </tr>


### PR DESCRIPTION
## Summary
- use petrol blue background with white text for specs table
- add light grey borders between spec rows

## Testing
- `npm run lint` *(fails: next: not found)*
- `npm run typecheck` *(fails: Cannot find module 'react' or its type declarations)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d54e2338832ba8b30594d1909d56