### PR TITLE
Randomize featured motos on home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { useMemo } from 'react';
 import { motion } from 'framer-motion';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -11,7 +12,10 @@ import { getAllMotos } from '@/lib/motos';
 
 export default function Home() {
   const motos = getAllMotos();
-  const featured = motos.slice(0, 6);
+  const featured = useMemo(() => {
+    const shuffled = [...motos].sort(() => Math.random() - 0.5);
+    return shuffled.slice(0, 6);
+  }, [motos]);
 
   return (
     <div className="min-h-screen">


### PR DESCRIPTION
## Summary
- Shuffle the moto catalogue and display six random entries in the featured section on the home page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm run typecheck` *(fails: cannot find modules and type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68b102d91cac832b995ef3cbfa58a2a4