### PR TITLE
feat: add motorcycle comparator

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "vaul": "^0.9.9",
     "xlsx": "^0.18.5",
     "zod": "^3.23.8",
-    "globby": "^14.0.1"
+    "globby": "^14.0.1",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "prettier": "^3.3.3",

--- a/src/app/motos/comparateur/page.tsx
+++ b/src/app/motos/comparateur/page.tsx
@@ -1,35 +1,21 @@
 'use client';
 
-import modelsData from '@/data/models.json';
-import { Button } from '@/components/ui/button';
-import useCompare from '@/hooks/use-compare';
-import type { Model } from '@/types';
+import CompareFilters from '@/components/comparator/CompareFilters';
+import CompareSlots from '@/components/comparator/CompareSlots';
+import SpecCheckboxes from '@/components/comparator/SpecCheckboxes';
+import CompareTable from '@/components/comparator/CompareTable';
 
-const models = modelsData as Model[];
-
-export default function ComparateurPage() {
-  const { compareMotos, removeMoto } = useCompare();
-  const selectedModels = models.filter((m) => compareMotos.includes(m.id));
-
+export default function Page() {
   return (
-    <div className="p-8">
-      <h1 className="text-3xl font-bold text-fg">Comparateur</h1>
-      {selectedModels.length === 0 ? (
-        <p className="mt-4 text-muted">
-          Aucun modèle sélectionné pour comparaison.
-        </p>
-      ) : (
-        <ul className="mt-4 space-y-2">
-          {selectedModels.map((model) => (
-            <li key={model.id} className="flex items-center gap-2">
-              <span className="text-fg">{model.name}</span>
-              <Button size="sm" variant="ghost" onClick={() => removeMoto(model.id)}>
-                Retirer
-              </Button>
-            </li>
-          ))}
-        </ul>
-      )}
+    <div className="flex flex-col md:flex-row gap-6 p-4">
+      <aside className="md:w-1/3 border-r pr-4">
+        <SpecCheckboxes />
+      </aside>
+      <main className="md:w-2/3 flex flex-col gap-4">
+        <CompareFilters />
+        <CompareSlots />
+        <CompareTable />
+      </main>
     </div>
   );
 }

--- a/src/components/comparator/CompareFilters.tsx
+++ b/src/components/comparator/CompareFilters.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams, usePathname } from 'next/navigation';
+import { brands, modelsByBrand } from '@/lib/moto-data';
+import { useCompare } from '@/store/useCompare';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+export default function CompareFilters() {
+  const [brand, setBrand] = useState('');
+  const [model, setModel] = useState('');
+
+  const { selected, addMoto, hydrateQS } = useCompare();
+
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+
+  // Hydrate from query string
+  useEffect(() => {
+    const qs = searchParams.get('m');
+    if (qs) {
+      hydrateQS(qs.split(','));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Update query string when selection changes
+  useEffect(() => {
+    const qs = selected.join(',');
+    const url = qs ? `${pathname}?m=${qs}` : pathname;
+    router.replace(url, { scroll: false });
+  }, [selected, pathname, router]);
+
+  const modelOptions = brand ? modelsByBrand(brand) : [];
+
+  const handleAdd = () => {
+    if (model) {
+      addMoto(model);
+      setModel('');
+    }
+  };
+
+  const disabled =
+    !model || selected.length >= 4 || selected.includes(model);
+
+  return (
+    <div className="flex flex-col sm:flex-row items-end gap-2">
+      <Select
+        value={brand}
+        onValueChange={(v) => {
+          setBrand(v);
+          setModel('');
+        }}
+      >
+        <SelectTrigger className="w-[160px]">
+          <SelectValue placeholder="Marque" />
+        </SelectTrigger>
+        <SelectContent>
+          {brands.map((b) => (
+            <SelectItem key={b} value={b}>
+              {b}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Select
+        value={model}
+        onValueChange={setModel}
+        disabled={!brand}
+      >
+        <SelectTrigger className="w-[160px]">
+          <SelectValue placeholder="Modèle" />
+        </SelectTrigger>
+        <SelectContent>
+          {modelOptions.map((m) => (
+            <SelectItem key={m.id} value={m.id}>
+              {m.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Button onClick={handleAdd} disabled={disabled}>
+        Ajouter
+      </Button>
+    </div>
+  );
+}
+

--- a/src/components/comparator/CompareSlots.tsx
+++ b/src/components/comparator/CompareSlots.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import Image from 'next/image';
+import { byId } from '@/lib/moto-data';
+import { useCompare } from '@/store/useCompare';
+import { Button } from '@/components/ui/button';
+
+export default function CompareSlots() {
+  const { selected, removeMoto } = useCompare();
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      {selected.map((id) => {
+        const moto = byId(id);
+        if (!moto) return null;
+        return (
+          <div
+            key={id}
+            className="border rounded p-2 flex flex-col items-center text-center"
+          >
+            {moto.image && (
+              <Image
+                src={moto.image}
+                alt={moto.model}
+                width={120}
+                height={80}
+                className="h-20 w-auto object-contain"
+              />
+            )}
+            <div className="mt-2 text-sm font-medium">
+              {moto.brand} {moto.model}
+            </div>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="mt-1"
+              onClick={() => removeMoto(id)}
+            >
+              Retirer
+            </Button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/comparator/CompareTable.tsx
+++ b/src/components/comparator/CompareTable.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useCompare } from '@/store/useCompare';
+import { byId } from '@/lib/moto-data';
+import { SPEC_ORDER, SPEC_LABELS } from '@/lib/specs';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '@/components/ui/table';
+
+function formatValue(key: string, value: any) {
+  if (value === undefined || value === null || value === '') return '—';
+  if (key === 'price_tnd' && typeof value === 'number') {
+    return value.toLocaleString('fr-TN') + ' TND';
+  }
+  if (typeof value === 'boolean') return value ? 'Oui' : 'Non';
+  return String(value);
+}
+
+export default function CompareTable() {
+  const { selected, checkedSpecs } = useCompare();
+  const motos = selected.map((id) => byId(id)).filter(Boolean);
+  const specs = SPEC_ORDER.filter((s) => checkedSpecs.has(s));
+
+  if (motos.length === 0) return null;
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="w-40">Caractéristique</TableHead>
+          {motos.map((m) => (
+            <TableHead key={m!.id}>
+              {m!.brand} {m!.model}
+            </TableHead>
+          ))}
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {specs.map((spec) => (
+          <TableRow key={spec}>
+            <TableCell className="font-medium">
+              {SPEC_LABELS[spec]}
+            </TableCell>
+            {motos.map((m) => (
+              <TableCell key={m!.id}>
+                {formatValue(spec, m!.specs[spec])}
+              </TableCell>
+            ))}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/src/components/comparator/SpecCheckboxes.tsx
+++ b/src/components/comparator/SpecCheckboxes.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { SPEC_ORDER, SPEC_LABELS } from '@/lib/specs';
+import { useCompare } from '@/store/useCompare';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+
+export default function SpecCheckboxes() {
+  const { checkedSpecs, toggleSpec } = useCompare();
+  return (
+    <div className="space-y-2">
+      {SPEC_ORDER.map((key) => (
+        <div key={key} className="flex items-center space-x-2">
+          <Checkbox
+            id={key}
+            checked={checkedSpecs.has(key)}
+            onCheckedChange={() => toggleSpec(key)}
+          />
+          <Label htmlFor={key}>{SPEC_LABELS[key]}</Label>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/moto-data.ts
+++ b/src/lib/moto-data.ts
@@ -1,0 +1,50 @@
+export type Moto = {
+  id: string;
+  brand: string;
+  model: string;
+  year?: number;
+  image?: string;
+  specs: Record<string, any>;
+};
+
+export const motos: Moto[] = [
+  {
+    id: 'yamaha-mt-07-2024',
+    brand: 'Yamaha',
+    model: 'MT-07',
+    year: 2024,
+    image: '/motos/mt07.png',
+    specs: {
+      price_tnd: 34990,
+      engine_cc: 689,
+      power_hp: 72,
+      torque_nm: 67,
+      weight_kg: 184,
+      abs: true,
+      gearbox: '6 vitesses',
+      cooling: 'liquide',
+    },
+  },
+  {
+    id: 'honda-cb500f-2024',
+    brand: 'Honda',
+    model: 'CB500F',
+    year: 2024,
+    image: '/motos/cb500f.png',
+    specs: {
+      price_tnd: 28990,
+      engine_cc: 471,
+      power_hp: 47,
+      torque_nm: 43,
+      weight_kg: 189,
+      abs: true,
+      gearbox: '6 vitesses',
+      cooling: 'liquide',
+    },
+  },
+];
+
+export const brands = Array.from(new Set(motos.map((m) => m.brand))).sort();
+export const modelsByBrand = (b: string) =>
+  motos.filter((m) => m.brand === b).map((m) => ({ id: m.id, label: m.model }));
+export const byId = (id: string) => motos.find((m) => m.id === id);

--- a/src/lib/specs.ts
+++ b/src/lib/specs.ts
@@ -1,0 +1,27 @@
+export const SPEC_ORDER = [
+  'price_tnd',
+  'engine_cc',
+  'power_hp',
+  'torque_nm',
+  'weight_kg',
+  'consumption_l_100',
+  'abs',
+  'gearbox',
+  'seat_height_mm',
+  'fuel_tank_l',
+  'cooling',
+] as const;
+
+export const SPEC_LABELS: Record<string, string> = {
+  price_tnd: 'Prix (TND)',
+  engine_cc: 'Cylindrée (cc)',
+  power_hp: 'Puissance (ch)',
+  torque_nm: 'Couple (Nm)',
+  weight_kg: 'Poids (kg)',
+  consumption_l_100: 'Conso (L/100km)',
+  abs: 'ABS',
+  gearbox: 'Boîte',
+  seat_height_mm: 'Hauteur de selle (mm)',
+  fuel_tank_l: 'Réservoir (L)',
+  cooling: 'Refroidissement',
+};

--- a/src/store/useCompare.ts
+++ b/src/store/useCompare.ts
@@ -1,0 +1,63 @@
+'use client';
+
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+export type State = {
+  selected: string[];
+  checkedSpecs: Set<string>;
+  addMoto: (id: string) => void;
+  removeMoto: (id: string) => void;
+  toggleSpec: (key: string) => void;
+  hydrateQS: (ids: string[]) => void;
+};
+
+const DEFAULT_SPECS = [
+  'price_tnd',
+  'engine_cc',
+  'power_hp',
+  'torque_nm',
+  'weight_kg',
+  'abs',
+];
+
+export const useCompare = create<State>()(
+  persist(
+    (set, get) => ({
+      selected: [],
+      checkedSpecs: new Set<string>(DEFAULT_SPECS),
+      addMoto: (id) =>
+        set((s) =>
+          s.selected.length >= 4 || s.selected.includes(id)
+            ? s
+            : { selected: [...s.selected, id] }
+        ),
+      removeMoto: (id) =>
+        set((s) => ({ selected: s.selected.filter((x) => x !== id) })),
+      toggleSpec: (key) =>
+        set((s) => {
+          const n = new Set(s.checkedSpecs);
+          n.has(key) ? n.delete(key) : n.add(key);
+          return { checkedSpecs: n };
+        }),
+      hydrateQS: (ids) => set({ selected: ids.slice(0, 4) }),
+    }),
+    {
+      name: 'compare-motos',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({
+        selected: state.selected,
+        checkedSpecs: Array.from(state.checkedSpecs),
+      }),
+      merge: (persisted, current) => {
+        const p = persisted as any;
+        return {
+          ...current,
+          ...p,
+          checkedSpecs: new Set(p.checkedSpecs || DEFAULT_SPECS),
+        } as State;
+      },
+    }
+  )
+);
+


### PR DESCRIPTION
## Summary
- add data and specs for motorcycle comparison
- implement zustand store with localStorage persistence
- build comparator UI with filters, slots, spec checkboxes and comparison table

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b1c6b06f64832baa2ab916b366f701