### PR TITLE
feat: improve moto comparator

### DIFF
--- a/src/app/motos/comparateur/page.tsx
+++ b/src/app/motos/comparateur/page.tsx
@@ -8,10 +8,10 @@ import CompareTable from '@/components/comparator/CompareTable';
 export default function Page() {
   return (
     <div className="flex flex-col md:flex-row gap-6 p-4">
-      <aside className="md:w-1/3 border-r pr-4">
+      <aside className="md:w-1/4 border-r pr-4">
         <SpecCheckboxes />
       </aside>
-      <main className="md:w-2/3 flex flex-col gap-4">
+      <main className="md:w-3/4 flex flex-col gap-4">
         <CompareFilters />
         <CompareSlots />
         <CompareTable />

--- a/src/components/comparator/CompareSlots.tsx
+++ b/src/components/comparator/CompareSlots.tsx
@@ -1,45 +1,51 @@
-'use client';
+"use client";
 
-import Image from 'next/image';
-import { byId } from '@/lib/moto-data';
-import { useCompare } from '@/store/useCompare';
-import { Button } from '@/components/ui/button';
+import { byId } from "@/lib/moto-data";
+import { useCompare } from "@/store/useCompare";
 
 export default function CompareSlots() {
-  const { selected, removeMoto } = useCompare();
+  const selected = useCompare((s) => s.selected);
+  const remove = useCompare((s) => s.removeMoto);
+
+  if (selected.length === 0) {
+    return (
+      <div className="border rounded p-4 text-sm text-gray-600">
+        Choisissez jusqu’à 4 motos via les filtres ci-dessus.
+      </div>
+    );
+  }
+
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
       {selected.map((id) => {
-        const moto = byId(id);
-        if (!moto) return null;
+        const m = byId(id);
+        if (!m) return null;
+        const src = m.image && m.image.startsWith("/") ? m.image : "/motos/placeholder.png";
         return (
-          <div
-            key={id}
-            className="border rounded p-2 flex flex-col items-center text-center"
-          >
-            {moto.image && (
-              <Image
-                src={moto.image}
-                alt={moto.model}
-                width={120}
-                height={80}
-                className="h-20 w-auto object-contain"
-              />
-            )}
-            <div className="mt-2 text-sm font-medium">
-              {moto.brand} {moto.model}
+          <div key={id} className="border rounded p-3 flex items-center gap-3">
+            <img
+              src={src}
+              alt={`${m.brand} ${m.model}`}
+              width={72}
+              height={48}
+              className="object-contain"
+            />
+            <div className="flex-1">
+              <div className="font-medium">
+                {m.brand} {m.model}
+                {m.year ? ` ${m.year}` : ""}
+              </div>
             </div>
-            <Button
-              size="sm"
-              variant="ghost"
-              className="mt-1"
-              onClick={() => removeMoto(id)}
+            <button
+              className="text-red-600 underline text-sm"
+              onClick={() => remove(id)}
             >
               Retirer
-            </Button>
+            </button>
           </div>
         );
       })}
     </div>
   );
 }
+

--- a/src/components/comparator/CompareTable.tsx
+++ b/src/components/comparator/CompareTable.tsx
@@ -1,59 +1,62 @@
-'use client';
+"use client";
 
-import { useCompare } from '@/store/useCompare';
-import { byId } from '@/lib/moto-data';
-import { SPEC_ORDER, SPEC_LABELS } from '@/lib/specs';
-import {
-  Table,
-  TableHeader,
-  TableBody,
-  TableRow,
-  TableHead,
-  TableCell,
-} from '@/components/ui/table';
+import { byId } from "@/lib/moto-data";
+import { SPEC_LABELS } from "@/lib/specs";
+import { useCompare } from "@/store/useCompare";
 
-function formatValue(key: string, value: any) {
-  if (value === undefined || value === null || value === '') return '—';
-  if (key === 'price_tnd' && typeof value === 'number') {
-    return value.toLocaleString('fr-TN') + ' TND';
+const fmtPrice = (v: any) => {
+  const n = Number(v);
+  if (Number.isFinite(n)) {
+    return n.toLocaleString("fr-TN") + " TND";
   }
-  if (typeof value === 'boolean') return value ? 'Oui' : 'Non';
-  return String(value);
-}
+  return "—";
+};
+
+const cellValue = (val: any, key: string) => {
+  if (val === undefined || val === null || val === "") return "—";
+  if (key === "price_tnd") return fmtPrice(val);
+  if (typeof val === "boolean") return val ? "Oui" : "Non";
+  return String(val);
+};
 
 export default function CompareTable() {
-  const { selected, checkedSpecs } = useCompare();
-  const motos = selected.map((id) => byId(id)).filter(Boolean);
-  const specs = SPEC_ORDER.filter((s) => checkedSpecs.has(s));
+  const selected = useCompare((s) => s.selected);
+  const checked = useCompare((s) => s.checkedSpecs);
 
-  if (motos.length === 0) return null;
+  const keys = Array.from(checked);
+
+  if (selected.length === 0 || keys.length === 0) return null;
+
+  const motos = selected.map((id) => byId(id)).filter(Boolean);
 
   return (
-    <Table>
-      <TableHeader>
-        <TableRow>
-          <TableHead className="w-40">Caractéristique</TableHead>
-          {motos.map((m) => (
-            <TableHead key={m!.id}>
-              {m!.brand} {m!.model}
-            </TableHead>
-          ))}
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {specs.map((spec) => (
-          <TableRow key={spec}>
-            <TableCell className="font-medium">
-              {SPEC_LABELS[spec]}
-            </TableCell>
+    <div className="overflow-auto">
+      <table className="min-w-full border border-gray-200 text-sm">
+        <thead className="bg-gray-50 sticky top-0">
+          <tr>
+            <th className="text-left p-2 border-b w-56">Caractéristique</th>
             {motos.map((m) => (
-              <TableCell key={m!.id}>
-                {formatValue(spec, m!.specs[spec])}
-              </TableCell>
+              <th key={m!.id} className="text-left p-2 border-b min-w-[180px]">
+                {m!.brand} {m!.model}
+                {m!.year ? ` ${m!.year}` : ""}
+              </th>
             ))}
-          </TableRow>
-        ))}
-      </TableBody>
-    </Table>
+          </tr>
+        </thead>
+        <tbody>
+          {keys.map((k) => (
+            <tr key={k} className="border-b">
+              <td className="p-2 font-medium w-56">{SPEC_LABELS[k] ?? k}</td>
+              {motos.map((m) => (
+                <td key={m!.id + "_" + k} className="p-2">
+                  {cellValue(m!.specs?.[k], k)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }
+

--- a/src/components/comparator/SpecCheckboxes.tsx
+++ b/src/components/comparator/SpecCheckboxes.tsx
@@ -1,24 +1,66 @@
-'use client';
+"use client";
 
-import { SPEC_ORDER, SPEC_LABELS } from '@/lib/specs';
-import { useCompare } from '@/store/useCompare';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Label } from '@/components/ui/label';
+import { useEffect } from "react";
+import { SPEC_KEYS, SPEC_LABELS } from "@/lib/specs";
+import { useCompare } from "@/store/useCompare";
+
+const DEFAULT_KEYS = [
+  "price_tnd",
+  "engine_cc",
+  "power_hp",
+  "torque_nm",
+  "weight_kg",
+  "abs",
+];
 
 export default function SpecCheckboxes() {
-  const { checkedSpecs, toggleSpec } = useCompare();
+  const checked = useCompare((s) => s.checkedSpecs);
+  const toggle = useCompare((s) => s.toggleSpec);
+
+  // si rien de coché au premier rendu, cocher un set par défaut (clé par clé)
+  useEffect(() => {
+    if (checked.size === 0) {
+      DEFAULT_KEYS.forEach((k) => toggle(k));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const allChecked = SPEC_KEYS.every((k) => checked.has(k));
+  const onToggleAll = () => {
+    if (allChecked) {
+      // tout décocher
+      SPEC_KEYS.forEach((k) => {
+        if (checked.has(k)) toggle(k);
+      });
+    } else {
+      // tout cocher
+      SPEC_KEYS.forEach((k) => {
+        if (!checked.has(k)) toggle(k);
+      });
+    }
+  };
+
   return (
     <div className="space-y-2">
-      {SPEC_ORDER.map((key) => (
-        <div key={key} className="flex items-center space-x-2">
-          <Checkbox
-            id={key}
-            checked={checkedSpecs.has(key)}
-            onCheckedChange={() => toggleSpec(key)}
-          />
-          <Label htmlFor={key}>{SPEC_LABELS[key]}</Label>
-        </div>
-      ))}
+      <div className="flex items-center justify-between pb-2 border-b">
+        <h2 className="font-semibold">Caractéristiques</h2>
+        <button className="text-sm underline" onClick={onToggleAll}>
+          {allChecked ? "Tout décocher" : "Tout cocher"}
+        </button>
+      </div>
+      <div className="grid grid-cols-1 gap-2 max-h-[70vh] overflow-auto pr-1">
+        {SPEC_KEYS.map((key) => (
+          <label key={key} className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={checked.has(key)}
+              onChange={() => toggle(key)}
+            />
+            <span>{SPEC_LABELS[key] ?? key}</span>
+          </label>
+        ))}
+      </div>
     </div>
   );
 }
+

--- a/src/lib/moto-data.ts
+++ b/src/lib/moto-data.ts
@@ -3,13 +3,13 @@ export type Moto = {
   brand: string;
   model: string;
   year?: number;
-  image?: string;
+  image?: string; // ex: "/motos/mt07.png"
   specs: Record<string, any>;
 };
 
 export const motos: Moto[] = [
   {
-    id: 'yamaha-mt-07-2024',
+    id: 'yamaha-mt-07-2024', // brand-model-year stable id
     brand: 'Yamaha',
     model: 'MT-07',
     year: 2024,
@@ -45,6 +45,37 @@ export const motos: Moto[] = [
 ];
 
 export const brands = Array.from(new Set(motos.map((m) => m.brand))).sort();
-export const modelsByBrand = (b: string) =>
-  motos.filter((m) => m.brand === b).map((m) => ({ id: m.id, label: m.model }));
+
+export const modelsByBrand = (brand: string) =>
+  motos
+    .filter((m) => m.brand === brand)
+    .map((m) => ({ id: m.id, label: m.model }));
+
 export const byId = (id: string) => motos.find((m) => m.id === id);
+
+/** Retourne toutes les clés de caractéristiques rencontrées dans motos[].specs */
+export const getAllSpecKeys = (): string[] => {
+  const s = new Set<string>();
+  for (const m of motos) {
+    Object.keys(m.specs || {}).forEach((k) => s.add(k));
+  }
+  // garder un ordre utile : prix et specs majeures d’abord, puis le reste alpha
+  const preferred = [
+    'price_tnd',
+    'engine_cc',
+    'power_hp',
+    'torque_nm',
+    'weight_kg',
+    'consumption_l_100',
+    'abs',
+    'gearbox',
+    'seat_height_mm',
+    'fuel_tank_l',
+    'cooling',
+  ];
+  const rest = [...s].filter((k) => !preferred.includes(k)).sort();
+  // si une clé préférée n’existe pas dans la data, on la saute automatiquement
+  const existingPreferred = preferred.filter((k) => s.has(k));
+  return [...existingPreferred, ...rest];
+};
+

--- a/src/lib/specs.ts
+++ b/src/lib/specs.ts
@@ -1,18 +1,8 @@
-export const SPEC_ORDER = [
-  'price_tnd',
-  'engine_cc',
-  'power_hp',
-  'torque_nm',
-  'weight_kg',
-  'consumption_l_100',
-  'abs',
-  'gearbox',
-  'seat_height_mm',
-  'fuel_tank_l',
-  'cooling',
-] as const;
+import { getAllSpecKeys } from '@/lib/moto-data';
 
-export const SPEC_LABELS: Record<string, string> = {
+export const SPEC_KEYS = getAllSpecKeys();
+
+const LABEL_OVERRIDES: Record<string, string> = {
   price_tnd: 'Prix (TND)',
   engine_cc: 'Cylindrée (cc)',
   power_hp: 'Puissance (ch)',
@@ -25,3 +15,14 @@ export const SPEC_LABELS: Record<string, string> = {
   fuel_tank_l: 'Réservoir (L)',
   cooling: 'Refroidissement',
 };
+
+const prettify = (k: string) =>
+  LABEL_OVERRIDES[k] ??
+  k
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+
+export const SPEC_LABELS: Record<string, string> = Object.fromEntries(
+  SPEC_KEYS.map((k) => [k, prettify(k)])
+);
+

--- a/src/store/useCompare.ts
+++ b/src/store/useCompare.ts
@@ -12,26 +12,18 @@ export type State = {
   hydrateQS: (ids: string[]) => void;
 };
 
-const DEFAULT_SPECS = [
-  'price_tnd',
-  'engine_cc',
-  'power_hp',
-  'torque_nm',
-  'weight_kg',
-  'abs',
-];
-
 export const useCompare = create<State>()(
   persist(
-    (set, get) => ({
+    (set) => ({
       selected: [],
-      checkedSpecs: new Set<string>(DEFAULT_SPECS),
+      checkedSpecs: new Set<string>(),
       addMoto: (id) =>
-        set((s) =>
-          s.selected.length >= 4 || s.selected.includes(id)
-            ? s
-            : { selected: [...s.selected, id] }
-        ),
+        set((s) => {
+          if (!id) return s;
+          if (s.selected.includes(id)) return s;
+          if (s.selected.length >= 4) return s;
+          return { selected: [...s.selected, id] };
+        }),
       removeMoto: (id) =>
         set((s) => ({ selected: s.selected.filter((x) => x !== id) })),
       toggleSpec: (key) =>
@@ -40,7 +32,8 @@ export const useCompare = create<State>()(
           n.has(key) ? n.delete(key) : n.add(key);
           return { checkedSpecs: n };
         }),
-      hydrateQS: (ids) => set({ selected: ids.slice(0, 4) }),
+      hydrateQS: (ids) =>
+        set({ selected: ids.filter(Boolean).slice(0, 4) }),
     }),
     {
       name: 'compare-motos',
@@ -54,7 +47,7 @@ export const useCompare = create<State>()(
         return {
           ...current,
           ...p,
-          checkedSpecs: new Set(p.checkedSpecs || DEFAULT_SPECS),
+          checkedSpecs: new Set(p.checkedSpecs || []),
         } as State;
       },
     }


### PR DESCRIPTION
## Summary
- aggregate moto spec keys dynamically and expose labels
- fix compare store and filters to support up to four models and query hydration
- add placeholder image fallback without bundling binary and render comparison table from selected specs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm run typecheck` *(fails: cannot find modules and implicit any errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b1cb3af870832b950040e54e2b6c7b