### PR TITLE
feat: add admin supabase integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "react-hook-form": "^7.53.0",
     "react-resizable-panels": "^2.1.3",
     "recharts": "^2.12.7",
+    "@supabase/supabase-js": "^2.45.4",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss": "3.3.3",

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { supabase } from '@/lib/supabaseClient';
+
+export default function AdminLoginPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [err, setErr] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      if (user) router.replace('/admin');
+    });
+  }, [router]);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setErr(null);
+    setLoading(true);
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    setLoading(false);
+    if (error) { setErr(error.message); return; }
+    router.replace('/admin');
+  };
+
+  return (
+    <main className="min-h-screen flex items-center justify-center px-4">
+      <form onSubmit={onSubmit} className="w-full max-w-sm rounded-2xl shadow p-6 space-y-4 border bg-white">
+        <h1 className="text-2xl font-semibold">Connexion admin</h1>
+        <div>
+          <label className="block text-sm mb-1">Email</label>
+          <input className="w-full border rounded px-3 py-2" type="email" value={email} onChange={e=>setEmail(e.target.value)} required />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Mot de passe</label>
+          <input className="w-full border rounded px-3 py-2" type="password" value={password} onChange={e=>setPassword(e.target.value)} required />
+        </div>
+        {err && <p className="text-red-600 text-sm">{err}</p>}
+        <button disabled={loading} className="w-full rounded-2xl px-4 py-2 border font-medium">
+          {loading ? 'Connexion…' : 'Se connecter'}
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { supabase } from '@/lib/supabaseClient';
+
+type Moto = {
+  id: string;
+  brand: string;
+  model: string;
+  year: number | null;
+  price: number | null;
+  main_image_url: string | null;
+  is_published: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+export default function AdminPage() {
+  const router = useRouter();
+  const [loading, setLoading] = useState(true);
+  const [guarded, setGuarded] = useState(false);
+  const [motos, setMotos] = useState<Moto[]>([]);
+  const [form, setForm] = useState<Partial<Moto>>({});
+  const [file, setFile] = useState<File | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) { router.replace('/admin/login'); return; }
+      const { data: allowed } = await supabase.rpc('is_admin');
+      if (!allowed) { setError('Accès refusé (non-admin)'); return; }
+      setGuarded(true);
+      setLoading(false);
+    })();
+  }, [router]);
+
+  useEffect(() => {
+    if (guarded) loadMotos();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [guarded]);
+
+  const loadMotos = async () => {
+    const { data, error } = await supabase.from('motos').select('*').order('updated_at', { ascending: false });
+    if (!error && data) setMotos(data as Moto[]);
+  };
+
+  const resetForm = () => { setForm({}); setFile(null); setError(null); };
+
+  const onSave = async () => {
+    setError(null);
+    if (!form.brand || !form.model) { setError('Brand et Model sont obligatoires'); return; }
+
+    // 1) Upload image si fichier choisi
+    let main_image_url = form.main_image_url ?? null;
+    if (file) {
+      const ext = (file.name.split('.').pop() || 'jpg').toLowerCase();
+      const path = `admin/${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`;
+      const { error: upErr } = await supabase.storage.from('motos').upload(path, file);
+      if (upErr) { setError('Upload image: ' + upErr.message); return; }
+      const { data: pub } = supabase.storage.from('motos').getPublicUrl(path);
+      main_image_url = pub.publicUrl;
+    }
+
+    const payload = {
+      brand: form.brand ?? '',
+      model: form.model ?? '',
+      year: form.year ?? null,
+      price: form.price ?? null,
+      is_published: form.is_published ?? true,
+      main_image_url,
+    };
+
+    if (form.id) {
+      const { error } = await supabase.from('motos').update(payload).eq('id', form.id);
+      if (error) { setError(error.message); return; }
+    } else {
+      const { error } = await supabase.from('motos').insert(payload);
+      if (error) { setError(error.message); return; }
+    }
+    resetForm();
+    await loadMotos();
+  };
+
+  const onDelete = async (id: string) => {
+    if (!confirm('Supprimer cette moto ?')) return;
+    const { error } = await supabase.from('motos').delete().eq('id', id);
+    if (error) { alert(error.message); return; }
+    await loadMotos();
+  };
+
+  const onLogout = async () => {
+    await supabase.auth.signOut();
+    router.replace('/admin/login');
+  };
+
+  if (loading) return <main className="p-6">Chargement…</main>;
+  if (error) return <main className="p-6 text-red-600">{error}</main>;
+  if (!guarded) return null;
+
+  return (
+    <main className="p-6 space-y-8">
+      <header className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Admin — Motos</h1>
+        <button onClick={onLogout} className="rounded-2xl border px-4 py-2">Se déconnecter</button>
+      </header>
+
+      {/* Formulaire création/édition */}
+      <section className="rounded-2xl border p-4 space-y-3 bg-white">
+        <h2 className="font-medium">{form.id ? 'Modifier la moto' : 'Ajouter une moto'}</h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+          <input className="border rounded px-3 py-2" placeholder="Brand" value={form.brand ?? ''} onChange={e=>setForm(f=>({...f, brand:e.target.value}))}/>
+          <input className="border rounded px-3 py-2" placeholder="Model" value={form.model ?? ''} onChange={e=>setForm(f=>({...f, model:e.target.value}))}/>
+          <input className="border rounded px-3 py-2" placeholder="Year" type="number" value={form.year ?? ''} onChange={e=>setForm(f=>({...f, year:e.target.value ? Number(e.target.value): null}))}/>
+          <input className="border rounded px-3 py-2" placeholder="Price" type="number" value={form.price ?? ''} onChange={e=>setForm(f=>({...f, price:e.target.value ? Number(e.target.value): null}))}/>
+          <input className="border rounded px-3 py-2" placeholder="Image URL (optionnel si upload)" value={form.main_image_url ?? ''} onChange={e=>setForm(f=>({...f, main_image_url:e.target.value}))}/>
+          <label className="inline-flex items-center gap-2 text-sm">
+            <input type="checkbox" checked={form.is_published ?? true} onChange={e=>setForm(f=>({...f, is_published:e.target.checked}))}/>
+            Publié
+          </label>
+          <div className="md:col-span-3">
+            <input type="file" accept="image/*" onChange={e=>setFile(e.target.files?.[0] ?? null)}/>
+          </div>
+        </div>
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+        <div className="flex gap-2">
+          <button onClick={onSave} className="rounded-2xl border px-4 py-2">Enregistrer</button>
+          {form.id && <button onClick={()=>setForm({})} className="rounded-2xl border px-4 py-2">Annuler</button>}
+        </div>
+      </section>
+
+      {/* Liste des motos */}
+      <section className="rounded-2xl border bg-white">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b">
+              <th className="text-left p-2">Image</th>
+              <th className="text-left p-2">Brand</th>
+              <th className="text-left p-2">Model</th>
+              <th className="text-left p-2">Year</th>
+              <th className="text-left p-2">Price</th>
+              <th className="text-left p-2">Publié</th>
+              <th className="text-left p-2">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {motos.map(m => (
+              <tr key={m.id} className="border-b">
+                <td className="p-2">{m.main_image_url ? <img src={m.main_image_url} alt="" className="h-12 w-16 object-cover rounded" /> : '-'}</td>
+                <td className="p-2">{m.brand}</td>
+                <td className="p-2">{m.model}</td>
+                <td className="p-2">{m.year ?? '-'}</td>
+                <td className="p-2">{m.price ?? '-'}</td>
+                <td className="p-2">{m.is_published ? 'Oui' : 'Non'}</td>
+                <td className="p-2 flex gap-2">
+                  <button className="border rounded px-2 py-1" onClick={()=>setForm(m)}>Éditer</button>
+                  <button className="border rounded px-2 py-1" onClick={()=>onDelete(m.id)}>Supprimer</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+    </main>
+  );
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,12 @@
+import { supabase } from './supabaseClient';
+
+export async function getCurrentUser() {
+  const { data: { user } } = await supabase.auth.getUser();
+  return user ?? null;
+}
+
+export async function isAdmin(): Promise<boolean> {
+  const { data, error } = await supabase.rpc('is_admin');
+  if (error) return false;
+  return !!data;
+}

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+export const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+);


### PR DESCRIPTION
## Summary
- add supabase-js dependency
- create supabase client and auth helpers
- implement admin login page
- add admin dashboard for CRUD motos with image upload

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find modules like react and @supabase/supabase-js)*

------
https://chatgpt.com/codex/tasks/task_e_68b201e3c948832bb8531991d0120d32