### PR TITLE
fix: remove duplicate dynamic export in admin page

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -7,7 +7,6 @@ import { useRouter } from 'next/navigation';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { getSupabaseClient } from '@/lib/supabaseClient';
 
-export const dynamic = 'force-dynamic';
 
 type Moto = {
   id: string;


### PR DESCRIPTION
## Summary
- fix build by removing duplicated `dynamic` export in admin page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*
- `npm run typecheck` *(fails: numerous TS errors due to missing dependencies)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b229d1bc38832b8c5fe992c956c199