### PR TITLE
feat: add supabase client and server helpers

### DIFF
--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,66 +1,74 @@
-'use client';
-export const dynamic = 'force-dynamic';
+"use client";
+export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
-import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import type { SupabaseClient } from '@supabase/supabase-js';
-import { getSupabaseClient } from '@/lib/supabaseClient';
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { supabaseClient } from "@/lib/supabaseClient";
 
 export default function AdminLoginPage() {
   const router = useRouter();
-  const [supabase, setSupabase] = useState<SupabaseClient | null>(null);
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
+  const supabase = supabaseClient;
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
   const [err, setErr] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-    const client = getSupabaseClient();
-    if (!client) {
-      setErr('Supabase non configuré');
-      return;
-    }
-    setSupabase(client);
-    client.auth.getUser().then(({ data: { user } }) => {
-      if (user) router.replace('/admin');
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      if (user) router.replace("/admin");
     });
-  }, [router]);
+  }, [router, supabase]);
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!supabase) return;
     setErr(null);
     setLoading(true);
-    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    const { error } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
     setLoading(false);
-    if (error) { setErr(error.message); return; }
-    router.replace('/admin');
+    if (error) {
+      setErr(error.message);
+      return;
+    }
+    router.replace("/admin");
   };
-
-  if (!supabase) {
-    return (
-      <main className="min-h-screen flex items-center justify-center px-4">
-        {err ? <p className="text-red-600">{err}</p> : 'Chargement…'}
-      </main>
-    );
-  }
 
   return (
     <main className="min-h-screen flex items-center justify-center px-4">
-      <form onSubmit={onSubmit} className="w-full max-w-sm rounded-2xl shadow p-6 space-y-4 border bg-white">
+      <form
+        onSubmit={onSubmit}
+        className="w-full max-w-sm rounded-2xl shadow p-6 space-y-4 border bg-white"
+      >
         <h1 className="text-2xl font-semibold">Connexion admin</h1>
         <div>
           <label className="block text-sm mb-1">Email</label>
-          <input className="w-full border rounded px-3 py-2" type="email" value={email} onChange={e=>setEmail(e.target.value)} required />
+          <input
+            className="w-full border rounded px-3 py-2"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
         </div>
         <div>
           <label className="block text-sm mb-1">Mot de passe</label>
-          <input className="w-full border rounded px-3 py-2" type="password" value={password} onChange={e=>setPassword(e.target.value)} required />
+          <input
+            className="w-full border rounded px-3 py-2"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
         </div>
         {err && <p className="text-red-600 text-sm">{err}</p>}
-        <button disabled={loading} className="w-full rounded-2xl px-4 py-2 border font-medium">
-          {loading ? 'Connexion…' : 'Se connecter'}
+        <button
+          disabled={loading}
+          className="w-full rounded-2xl px-4 py-2 border font-medium"
+        >
+          {loading ? "Connexion…" : "Se connecter"}
         </button>
       </form>
     </main>

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -4,11 +4,11 @@ export const revalidate = 0;
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { supabaseClient } from "@/lib/supabaseClient";
+import { getSupabaseClient } from "@/lib/supabaseClient";
 
 export default function AdminLoginPage() {
   const router = useRouter();
-  const supabase = supabaseClient;
+  const supabase = getSupabaseClient();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [err, setErr] = useState<string | null>(null);

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -8,23 +8,23 @@ import { getSupabaseClient } from "@/lib/supabaseClient";
 
 export default function AdminLoginPage() {
   const router = useRouter();
-  const supabase = getSupabaseClient();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [err, setErr] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
+    const supabase = getSupabaseClient();
     supabase.auth.getUser().then(({ data: { user } }) => {
       if (user) router.replace("/admin");
     });
-  }, [router, supabase]);
+  }, [router]);
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setErr(null);
     setLoading(true);
-    const { error } = await supabase.auth.signInWithPassword({
+    const { error } = await getSupabaseClient().auth.signInWithPassword({
       email,
       password,
     });

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -20,7 +20,6 @@ type Moto = {
 
 export default function AdminPage() {
   const router = useRouter();
-  const supabase = getSupabaseClient();
   const [loading, setLoading] = useState(true);
   const [guarded, setGuarded] = useState(false);
   const [motos, setMotos] = useState<Moto[]>([]);
@@ -30,6 +29,7 @@ export default function AdminPage() {
 
   useEffect(() => {
     (async () => {
+      const supabase = getSupabaseClient();
       const {
         data: { user },
       } = await supabase.auth.getUser();
@@ -45,7 +45,7 @@ export default function AdminPage() {
       setGuarded(true);
       setLoading(false);
     })();
-  }, [router, supabase]);
+  }, [router]);
 
   useEffect(() => {
     if (guarded) loadMotos();
@@ -53,6 +53,7 @@ export default function AdminPage() {
   }, [guarded]);
 
   const loadMotos = async () => {
+    const supabase = getSupabaseClient();
     const { data, error } = await supabase
       .from("motos")
       .select("*")
@@ -72,6 +73,8 @@ export default function AdminPage() {
       setError("Brand et Model sont obligatoires");
       return;
     }
+
+    const supabase = getSupabaseClient();
 
     // 1) Upload image si fichier choisi
     let main_image_url = form.main_image_url ?? null;
@@ -120,6 +123,7 @@ export default function AdminPage() {
 
   const onDelete = async (id: string) => {
     if (!confirm("Supprimer cette moto ?")) return;
+    const supabase = getSupabaseClient();
     const { error } = await supabase.from("motos").delete().eq("id", id);
     if (error) {
       alert(error.message);
@@ -129,7 +133,7 @@ export default function AdminPage() {
   };
 
   const onLogout = async () => {
-    await supabase.auth.signOut();
+    await getSupabaseClient().auth.signOut();
     router.replace("/admin/login");
   };
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -4,7 +4,7 @@ export const revalidate = 0;
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { supabaseClient } from "@/lib/supabaseClient";
+import { getSupabaseClient } from "@/lib/supabaseClient";
 
 type Moto = {
   id: string;
@@ -20,7 +20,7 @@ type Moto = {
 
 export default function AdminPage() {
   const router = useRouter();
-  const supabase = supabaseClient;
+  const supabase = getSupabaseClient();
   const [loading, setLoading] = useState(true);
   const [guarded, setGuarded] = useState(false);
   const [motos, setMotos] = useState<Moto[]>([]);

--- a/src/app/admin/specs/[motoId]/page.tsx
+++ b/src/app/admin/specs/[motoId]/page.tsx
@@ -4,7 +4,7 @@ export const revalidate = 0;
 
 import { useEffect, useMemo, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { supabaseClient } from "@/lib/supabaseClient";
+import { getSupabaseClient } from "@/lib/supabaseClient";
 
 type Spec = {
   id: string;
@@ -29,7 +29,7 @@ export default function MotoSpecsPage() {
   const router = useRouter();
   const motoId = String(params.motoId);
 
-  const supabase = supabaseClient;
+  const supabase = getSupabaseClient();
   const [loading, setLoading] = useState(true);
   const [guarded, setGuarded] = useState(false);
 

--- a/src/app/admin/specs/[motoId]/page.tsx
+++ b/src/app/admin/specs/[motoId]/page.tsx
@@ -1,11 +1,10 @@
-'use client';
-export const dynamic = 'force-dynamic';
+"use client";
+export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
-import { useEffect, useMemo, useState } from 'react';
-import { useParams, useRouter } from 'next/navigation';
-import type { SupabaseClient } from '@supabase/supabase-js';
-import { getSupabaseClient } from '@/lib/supabaseClient';
+import { useEffect, useMemo, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { supabaseClient } from "@/lib/supabaseClient";
 
 type Spec = {
   id: string;
@@ -30,7 +29,7 @@ export default function MotoSpecsPage() {
   const router = useRouter();
   const motoId = String(params.motoId);
 
-  const [supabase, setSupabase] = useState<SupabaseClient | null>(null);
+  const supabase = supabaseClient;
   const [loading, setLoading] = useState(true);
   const [guarded, setGuarded] = useState(false);
 
@@ -40,36 +39,32 @@ export default function MotoSpecsPage() {
 
   // Formulaire (nouvelle ligne)
   const [form, setForm] = useState<Partial<Spec>>({
-    category: '',
-    subcategory: '',
-    key_name: '',
-    value_text: '',
-    unit: '',
+    category: "",
+    subcategory: "",
+    key_name: "",
+    value_text: "",
+    unit: "",
     sort_order: 0,
   });
 
   // Édition inline (par id)
   const [editing, setEditing] = useState<Record<string, Partial<Spec>>>({});
 
-  // Initialize Supabase client once on mount
-  useEffect(() => {
-    const client = getSupabaseClient();
-    if (!client) {
-      setError('Supabase non configuré');
-      setLoading(false);
-      return;
-    }
-    setSupabase(client);
-  }, []);
-
   // Guard admin
   useEffect(() => {
-    if (!supabase) return;
     (async () => {
-      const { data: { user } } = await supabase.auth.getUser();
-      if (!user) { router.replace('/admin/login'); return; }
-      const { data: allowed } = await supabase.rpc('is_admin');
-      if (!allowed) { setError('Accès refusé (non-admin)'); return; }
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) {
+        router.replace("/admin/login");
+        return;
+      }
+      const { data: allowed } = await supabase.rpc("is_admin");
+      if (!allowed) {
+        setError("Accès refusé (non-admin)");
+        return;
+      }
       setGuarded(true);
       setLoading(false);
     })();
@@ -77,89 +72,111 @@ export default function MotoSpecsPage() {
 
   // Charger moto + specs
   useEffect(() => {
-    if (!guarded || !supabase) return;
+    if (!guarded) return;
     (async () => {
       await loadMoto();
       await loadSpecs();
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [guarded, supabase]);
+  }, [guarded]);
 
   const loadMoto = async () => {
-    if (!supabase) return;
     const { data, error } = await supabase
-      .from('motos')
-      .select('id, brand, model')
-      .eq('id', motoId)
+      .from("motos")
+      .select("id, brand, model")
+      .eq("id", motoId)
       .single();
     if (!error && data) setMoto(data as Moto);
   };
 
   const loadSpecs = async () => {
-    if (!supabase) return;
     const { data, error } = await supabase
-      .from('moto_specs')
-      .select('*')
-      .eq('moto_id', motoId)
-      .order('category', { ascending: true, nullsFirst: true })
-      .order('subcategory', { ascending: true, nullsFirst: true })
-      .order('sort_order', { ascending: true, nullsFirst: true });
-    if (error) { setError(error.message); return; }
+      .from("moto_specs")
+      .select("*")
+      .eq("moto_id", motoId)
+      .order("category", { ascending: true, nullsFirst: true })
+      .order("subcategory", { ascending: true, nullsFirst: true })
+      .order("sort_order", { ascending: true, nullsFirst: true });
+    if (error) {
+      setError(error.message);
+      return;
+    }
     setSpecs((data ?? []) as Spec[]);
   };
 
   const groups = useMemo(() => {
     // Regroupe par (category -> subcategory)
-    const map = new Map<string, { category: string; subcategory: string; items: Spec[] }>();
+    const map = new Map<
+      string,
+      { category: string; subcategory: string; items: Spec[] }
+    >();
     for (const s of specs) {
-      const cat = s.category ?? '';
-      const sub = s.subcategory ?? '';
+      const cat = s.category ?? "";
+      const sub = s.subcategory ?? "";
       const key = `${cat}__${sub}`;
-      if (!map.has(key)) map.set(key, { category: cat, subcategory: sub, items: [] });
+      if (!map.has(key))
+        map.set(key, { category: cat, subcategory: sub, items: [] });
       map.get(key)!.items.push(s);
     }
     return Array.from(map.values());
   }, [specs]);
 
   const updateEditing = (id: string, patch: Partial<Spec>) => {
-    setEditing(prev => ({ ...prev, [id]: { ...prev[id], ...patch } }));
+    setEditing((prev) => ({ ...prev, [id]: { ...prev[id], ...patch } }));
   };
 
   const onCreate = async () => {
-    if (!supabase) return;
     setError(null);
-    if (!form.key_name) { setError('Le champ "key_name" est obligatoire.'); return; }
+    if (!form.key_name) {
+      setError('Le champ "key_name" est obligatoire.');
+      return;
+    }
     const payload = {
       moto_id: motoId,
-      category: (form.category ?? '') || null,
-      subcategory: (form.subcategory ?? '') || null,
-      key_name: form.key_name ?? '',
-      value_text: (form.value_text ?? '') || null,
-      unit: (form.unit ?? '') || null,
+      category: (form.category ?? "") || null,
+      subcategory: (form.subcategory ?? "") || null,
+      key_name: form.key_name ?? "",
+      value_text: (form.value_text ?? "") || null,
+      unit: (form.unit ?? "") || null,
       sort_order: form.sort_order ?? 0,
     };
-    const { error } = await supabase.from('moto_specs').insert(payload);
-    if (error) { setError(error.message); return; }
-    setForm({ category: '', subcategory: '', key_name: '', value_text: '', unit: '', sort_order: 0 });
+    const { error } = await supabase.from("moto_specs").insert(payload);
+    if (error) {
+      setError(error.message);
+      return;
+    }
+    setForm({
+      category: "",
+      subcategory: "",
+      key_name: "",
+      value_text: "",
+      unit: "",
+      sort_order: 0,
+    });
     await loadSpecs();
   };
 
   const onSaveRow = async (row: Spec) => {
-    if (!supabase) return;
     setError(null);
     const patch = editing[row.id] ?? {};
     if (!patch || Object.keys(patch).length === 0) return;
     const payload = {
       category: (patch.category ?? row.category) || null,
       subcategory: (patch.subcategory ?? row.subcategory) || null,
-      key_name: (patch.key_name ?? row.key_name) || '',
+      key_name: (patch.key_name ?? row.key_name) || "",
       value_text: (patch.value_text ?? row.value_text) || null,
       unit: (patch.unit ?? row.unit) || null,
-      sort_order: (patch.sort_order ?? row.sort_order) ?? 0,
+      sort_order: patch.sort_order ?? row.sort_order ?? 0,
     };
-    const { error } = await supabase.from('moto_specs').update(payload).eq('id', row.id);
-    if (error) { setError(error.message); return; }
-    setEditing(prev => {
+    const { error } = await supabase
+      .from("moto_specs")
+      .update(payload)
+      .eq("id", row.id);
+    if (error) {
+      setError(error.message);
+      return;
+    }
+    setEditing((prev) => {
       const { [row.id]: _, ...rest } = prev; // remove edited cache
       return rest;
     });
@@ -167,14 +184,19 @@ export default function MotoSpecsPage() {
   };
 
   const onDeleteRow = async (row: Spec) => {
-    if (!supabase) return;
-    if (!confirm('Supprimer cette caractéristique ?')) return;
-    const { error } = await supabase.from('moto_specs').delete().eq('id', row.id);
-    if (error) { alert(error.message); return; }
+    if (!confirm("Supprimer cette caractéristique ?")) return;
+    const { error } = await supabase
+      .from("moto_specs")
+      .delete()
+      .eq("id", row.id);
+    if (error) {
+      alert(error.message);
+      return;
+    }
     await loadSpecs();
   };
 
-  const onBack = () => router.push('/admin');
+  const onBack = () => router.push("/admin");
 
   if (loading) return <main className="p-6">Chargement…</main>;
   if (error) return <main className="p-6 text-red-600">{error}</main>;
@@ -184,8 +206,15 @@ export default function MotoSpecsPage() {
     <main className="p-6 space-y-8">
       <header className="flex items-center justify-between">
         <div className="space-y-1">
-          <h1 className="text-2xl font-semibold">Caractéristiques — {moto ? `${moto.brand} ${moto.model}` : ''}</h1>
-          <button onClick={onBack} className="rounded-2xl border px-3 py-1 text-sm">← Retour à l’admin</button>
+          <h1 className="text-2xl font-semibold">
+            Caractéristiques — {moto ? `${moto.brand} ${moto.model}` : ""}
+          </h1>
+          <button
+            onClick={onBack}
+            className="rounded-2xl border px-3 py-1 text-sm"
+          >
+            ← Retour à l’admin
+          </button>
         </div>
       </header>
 
@@ -193,31 +222,87 @@ export default function MotoSpecsPage() {
       <section className="rounded-2xl border p-4 space-y-3 bg-white">
         <h2 className="font-medium">Ajouter une ligne</h2>
         <div className="grid grid-cols-1 md:grid-cols-6 gap-3">
-          <input className="border rounded px-3 py-2" placeholder="Catégorie" value={form.category ?? ''} onChange={e=>setForm(f=>({...f, category:e.target.value}))}/>
-          <input className="border rounded px-3 py-2" placeholder="Sous-catégorie" value={form.subcategory ?? ''} onChange={e=>setForm(f=>({...f, subcategory:e.target.value}))}/>
-          <input className="border rounded px-3 py-2 md:col-span-2" placeholder="Nom de la clé (key_name)*" value={form.key_name ?? ''} onChange={e=>setForm(f=>({...f, key_name:e.target.value}))}/>
-          <input className="border rounded px-3 py-2" placeholder="Valeur" value={form.value_text ?? ''} onChange={e=>setForm(f=>({...f, value_text:e.target.value}))}/>
-          <input className="border rounded px-3 py-2" placeholder="Unité (ex: cc, kg, mm…)" value={form.unit ?? ''} onChange={e=>setForm(f=>({...f, unit:e.target.value}))}/>
-          <input className="border rounded px-3 py-2" placeholder="Ordre" type="number" value={form.sort_order ?? 0} onChange={e=>setForm(f=>({...f, sort_order:e.target.value ? Number(e.target.value): 0}))}/>
+          <input
+            className="border rounded px-3 py-2"
+            placeholder="Catégorie"
+            value={form.category ?? ""}
+            onChange={(e) =>
+              setForm((f) => ({ ...f, category: e.target.value }))
+            }
+          />
+          <input
+            className="border rounded px-3 py-2"
+            placeholder="Sous-catégorie"
+            value={form.subcategory ?? ""}
+            onChange={(e) =>
+              setForm((f) => ({ ...f, subcategory: e.target.value }))
+            }
+          />
+          <input
+            className="border rounded px-3 py-2 md:col-span-2"
+            placeholder="Nom de la clé (key_name)*"
+            value={form.key_name ?? ""}
+            onChange={(e) =>
+              setForm((f) => ({ ...f, key_name: e.target.value }))
+            }
+          />
+          <input
+            className="border rounded px-3 py-2"
+            placeholder="Valeur"
+            value={form.value_text ?? ""}
+            onChange={(e) =>
+              setForm((f) => ({ ...f, value_text: e.target.value }))
+            }
+          />
+          <input
+            className="border rounded px-3 py-2"
+            placeholder="Unité (ex: cc, kg, mm…)"
+            value={form.unit ?? ""}
+            onChange={(e) => setForm((f) => ({ ...f, unit: e.target.value }))}
+          />
+          <input
+            className="border rounded px-3 py-2"
+            placeholder="Ordre"
+            type="number"
+            value={form.sort_order ?? 0}
+            onChange={(e) =>
+              setForm((f) => ({
+                ...f,
+                sort_order: e.target.value ? Number(e.target.value) : 0,
+              }))
+            }
+          />
         </div>
         <div className="flex gap-2">
-          <button onClick={onCreate} className="rounded-2xl border px-4 py-2">Ajouter</button>
+          <button onClick={onCreate} className="rounded-2xl border px-4 py-2">
+            Ajouter
+          </button>
         </div>
-        <p className="text-xs text-gray-500">* <strong>key_name</strong> est obligatoire (ex: “Cylindrée”).</p>
+        <p className="text-xs text-gray-500">
+          * <strong>key_name</strong> est obligatoire (ex: “Cylindrée”).
+        </p>
       </section>
 
       {/* Liste groupée par Catégorie / Sous-catégorie */}
       <section className="rounded-2xl border bg-white">
         {groups.length === 0 ? (
-          <div className="p-4 text-sm text-gray-600">Aucune caractéristique pour le moment.</div>
+          <div className="p-4 text-sm text-gray-600">
+            Aucune caractéristique pour le moment.
+          </div>
         ) : (
           <div className="divide-y">
             {groups.map((g, gi) => (
               <div key={gi} className="p-4">
                 <div className="mb-3">
                   <h3 className="text-lg font-medium">
-                    {g.category || <span className="italic text-gray-500">Sans catégorie</span>}
-                    {g.subcategory ? <span className="text-gray-500"> / {g.subcategory}</span> : null}
+                    {g.category || (
+                      <span className="italic text-gray-500">
+                        Sans catégorie
+                      </span>
+                    )}
+                    {g.subcategory ? (
+                      <span className="text-gray-500"> / {g.subcategory}</span>
+                    ) : null}
                   </h3>
                 </div>
                 <div className="overflow-x-auto">
@@ -232,48 +317,93 @@ export default function MotoSpecsPage() {
                       </tr>
                     </thead>
                     <tbody>
-                      {g.items.map(row => {
+                      {g.items.map((row) => {
                         const draft = editing[row.id] ?? {};
                         return (
                           <tr key={row.id} className="border-b align-top">
                             <td className="p-2">
-                              <input className="border rounded px-2 py-1 w-full"
+                              <input
+                                className="border rounded px-2 py-1 w-full"
                                 defaultValue={row.key_name}
-                                onChange={e=>updateEditing(row.id, { key_name: e.target.value })}
+                                onChange={(e) =>
+                                  updateEditing(row.id, {
+                                    key_name: e.target.value,
+                                  })
+                                }
                               />
                               <div className="grid grid-cols-2 gap-2 mt-1">
-                                <input className="border rounded px-2 py-1" placeholder="Catégorie"
-                                  defaultValue={row.category ?? ''}
-                                  onChange={e=>updateEditing(row.id, { category: e.target.value })}
+                                <input
+                                  className="border rounded px-2 py-1"
+                                  placeholder="Catégorie"
+                                  defaultValue={row.category ?? ""}
+                                  onChange={(e) =>
+                                    updateEditing(row.id, {
+                                      category: e.target.value,
+                                    })
+                                  }
                                 />
-                                <input className="border rounded px-2 py-1" placeholder="Sous-catégorie"
-                                  defaultValue={row.subcategory ?? ''}
-                                  onChange={e=>updateEditing(row.id, { subcategory: e.target.value })}
+                                <input
+                                  className="border rounded px-2 py-1"
+                                  placeholder="Sous-catégorie"
+                                  defaultValue={row.subcategory ?? ""}
+                                  onChange={(e) =>
+                                    updateEditing(row.id, {
+                                      subcategory: e.target.value,
+                                    })
+                                  }
                                 />
                               </div>
                             </td>
                             <td className="p-2">
-                              <textarea className="border rounded px-2 py-1 w-full"
+                              <textarea
+                                className="border rounded px-2 py-1 w-full"
                                 rows={2}
-                                defaultValue={row.value_text ?? ''}
-                                onChange={e=>updateEditing(row.id, { value_text: e.target.value })}
+                                defaultValue={row.value_text ?? ""}
+                                onChange={(e) =>
+                                  updateEditing(row.id, {
+                                    value_text: e.target.value,
+                                  })
+                                }
                               />
                             </td>
                             <td className="p-2">
-                              <input className="border rounded px-2 py-1 w-28"
-                                defaultValue={row.unit ?? ''}
-                                onChange={e=>updateEditing(row.id, { unit: e.target.value })}
+                              <input
+                                className="border rounded px-2 py-1 w-28"
+                                defaultValue={row.unit ?? ""}
+                                onChange={(e) =>
+                                  updateEditing(row.id, {
+                                    unit: e.target.value,
+                                  })
+                                }
                               />
                             </td>
                             <td className="p-2">
-                              <input className="border rounded px-2 py-1 w-20" type="number"
+                              <input
+                                className="border rounded px-2 py-1 w-20"
+                                type="number"
                                 defaultValue={row.sort_order ?? 0}
-                                onChange={e=>updateEditing(row.id, { sort_order: e.target.value ? Number(e.target.value) : 0 })}
+                                onChange={(e) =>
+                                  updateEditing(row.id, {
+                                    sort_order: e.target.value
+                                      ? Number(e.target.value)
+                                      : 0,
+                                  })
+                                }
                               />
                             </td>
                             <td className="p-2 space-x-2 whitespace-nowrap">
-                              <button className="border rounded px-2 py-1" onClick={()=>onSaveRow(row)}>Enregistrer</button>
-                              <button className="border rounded px-2 py-1" onClick={()=>onDeleteRow(row)}>Supprimer</button>
+                              <button
+                                className="border rounded px-2 py-1"
+                                onClick={() => onSaveRow(row)}
+                              >
+                                Enregistrer
+                              </button>
+                              <button
+                                className="border rounded px-2 py-1"
+                                onClick={() => onDeleteRow(row)}
+                              >
+                                Supprimer
+                              </button>
                             </td>
                           </tr>
                         );
@@ -289,4 +419,3 @@ export default function MotoSpecsPage() {
     </main>
   );
 }
-

--- a/src/app/admin/specs/[motoId]/page.tsx
+++ b/src/app/admin/specs/[motoId]/page.tsx
@@ -28,8 +28,6 @@ export default function MotoSpecsPage() {
   const params = useParams();
   const router = useRouter();
   const motoId = String(params.motoId);
-
-  const supabase = getSupabaseClient();
   const [loading, setLoading] = useState(true);
   const [guarded, setGuarded] = useState(false);
 
@@ -53,6 +51,7 @@ export default function MotoSpecsPage() {
   // Guard admin
   useEffect(() => {
     (async () => {
+      const supabase = getSupabaseClient();
       const {
         data: { user },
       } = await supabase.auth.getUser();
@@ -68,7 +67,7 @@ export default function MotoSpecsPage() {
       setGuarded(true);
       setLoading(false);
     })();
-  }, [router, supabase]);
+  }, [router]);
 
   // Charger moto + specs
   useEffect(() => {
@@ -81,6 +80,7 @@ export default function MotoSpecsPage() {
   }, [guarded]);
 
   const loadMoto = async () => {
+    const supabase = getSupabaseClient();
     const { data, error } = await supabase
       .from("motos")
       .select("id, brand, model")
@@ -90,6 +90,7 @@ export default function MotoSpecsPage() {
   };
 
   const loadSpecs = async () => {
+    const supabase = getSupabaseClient();
     const { data, error } = await supabase
       .from("moto_specs")
       .select("*")
@@ -131,6 +132,7 @@ export default function MotoSpecsPage() {
       setError('Le champ "key_name" est obligatoire.');
       return;
     }
+    const supabase = getSupabaseClient();
     const payload = {
       moto_id: motoId,
       category: (form.category ?? "") || null,
@@ -160,6 +162,7 @@ export default function MotoSpecsPage() {
     setError(null);
     const patch = editing[row.id] ?? {};
     if (!patch || Object.keys(patch).length === 0) return;
+    const supabase = getSupabaseClient();
     const payload = {
       category: (patch.category ?? row.category) || null,
       subcategory: (patch.subcategory ?? row.subcategory) || null,
@@ -185,6 +188,7 @@ export default function MotoSpecsPage() {
 
   const onDeleteRow = async (row: Spec) => {
     if (!confirm("Supprimer cette caractéristique ?")) return;
+    const supabase = getSupabaseClient();
     const { error } = await supabase
       .from("moto_specs")
       .delete()

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,16 +1,14 @@
-import { getSupabaseClient } from './supabaseClient';
+import { supabaseClient } from "./supabaseClient";
 
 export async function getCurrentUser() {
-  const client = getSupabaseClient();
-  if (!client) return null;
-  const { data: { user } } = await client.auth.getUser();
+  const {
+    data: { user },
+  } = await supabaseClient.auth.getUser();
   return user ?? null;
 }
 
 export async function isAdmin(): Promise<boolean> {
-  const client = getSupabaseClient();
-  if (!client) return false;
-  const { data, error } = await client.rpc('is_admin');
+  const { data, error } = await supabaseClient.rpc("is_admin");
   if (error) return false;
   return !!data;
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,14 +1,16 @@
-import { supabaseClient } from "./supabaseClient";
+import { getSupabaseClient } from "./supabaseClient";
 
 export async function getCurrentUser() {
+  const supabase = getSupabaseClient();
   const {
     data: { user },
-  } = await supabaseClient.auth.getUser();
+  } = await supabase.auth.getUser();
   return user ?? null;
 }
 
 export async function isAdmin(): Promise<boolean> {
-  const { data, error } = await supabaseClient.rpc("is_admin");
+  const supabase = getSupabaseClient();
+  const { data, error } = await supabase.rpc("is_admin");
   if (error) return false;
   return !!data;
 }

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,7 +1,20 @@
 "use client";
-import { createClient } from "@supabase/supabase-js";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+let client: SupabaseClient | undefined;
 
-export const supabaseClient = createClient(url, anonKey);
+export function getSupabaseClient() {
+  if (client) return client;
+  const url =
+    process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL;
+  const anonKey =
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
+    process.env.SUPABASE_ANON_KEY;
+  if (!url || !anonKey) {
+    throw new Error(
+      "Missing Supabase env vars NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY"
+    );
+  }
+  client = createClient(url, anonKey);
+  return client;
+}

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,14 +1,7 @@
-'use client';
-import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+"use client";
+import { createClient } from "@supabase/supabase-js";
 
-let client: SupabaseClient | null = null;
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
 
-export function getSupabaseClient(): SupabaseClient | null {
-  if (client) return client;
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-  if (!url || !anonKey) return null;
-  client = createClient(url, anonKey);
-  return client;
-}
-
+export const supabaseClient = createClient(url, anonKey);

--- a/src/lib/supabaseServer.ts
+++ b/src/lib/supabaseServer.ts
@@ -1,10 +1,12 @@
 import { cookies } from "next/headers";
-import { createClient } from "@supabase/supabase-js";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!; // jamais exposé côté client
-
-function createServerClient() {
+function createServerClient(): SupabaseClient {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !serviceKey) {
+    throw new Error("Missing Supabase server env vars");
+  }
   const cookieStore = cookies();
   const access = cookieStore.get("sb-access-token")?.value;
   return createClient(url, serviceKey, {

--- a/src/lib/supabaseServer.ts
+++ b/src/lib/supabaseServer.ts
@@ -1,0 +1,37 @@
+import { cookies } from "next/headers";
+import { createClient } from "@supabase/supabase-js";
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!; // jamais exposé côté client
+
+function createServerClient() {
+  const cookieStore = cookies();
+  const access = cookieStore.get("sb-access-token")?.value;
+  return createClient(url, serviceKey, {
+    global: { headers: access ? { Authorization: `Bearer ${access}` } : {} },
+  });
+}
+
+export async function getSession() {
+  const supabase = createServerClient();
+  const { data } = await supabase.auth.getUser();
+  return data.user;
+}
+
+export async function isAdmin() {
+  const supabase = createServerClient();
+  const { data: allowed } = await supabase.rpc("is_admin");
+  if (allowed) return true;
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return false;
+  const { data } = await supabase
+    .from("admins")
+    .select("id")
+    .eq("id", user.id)
+    .single();
+  return !!data;
+}
+
+export { createServerClient };


### PR DESCRIPTION
## Summary
- add browser Supabase client wrapper
- provide server-side Supabase helpers and admin checks
- refactor admin pages to use shared client

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@supabase%2fsupabase-js)*
- `npm run typecheck` *(fails: Cannot find module '@supabase/supabase-js')*

------
https://chatgpt.com/codex/tasks/task_e_68b230c22ba0832bb204183c760ecfdd