### PR TITLE
feat(admin): add navigation and server guard

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react';
+import { redirect } from 'next/navigation';
+import { getSession, isAdmin } from '@/lib/supabaseServer';
+import AdminNav from '@/components/admin/AdminNav';
+
+export default async function AdminLayout({ children }: { children: ReactNode }) {
+  const user = await getSession();
+  const ok = user && await isAdmin();
+  if (!ok) redirect('/');
+  return (
+    <section className="p-6">
+      <AdminNav />
+      {children}
+    </section>
+  );
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,3 +1,6 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 import { ReactNode } from 'react';
 import { redirect } from 'next/navigation';
 import { getSession, isAdmin } from '@/lib/supabaseServer';

--- a/src/components/admin/AdminNav.tsx
+++ b/src/components/admin/AdminNav.tsx
@@ -1,0 +1,28 @@
+'use client';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import clsx from 'clsx';
+
+const links = [
+  { href: '/admin', label: 'Dashboard' },
+  { href: '/admin/motos', label: 'Motos' },
+  { href: '/admin/categories', label: 'Catégories' },
+  { href: '/admin/clients', label: 'Clients' },
+];
+
+export default function AdminNav() {
+  const pathname = usePathname();
+  return (
+    <nav className="flex gap-4 border-b mb-6">
+      {links.map(l => (
+        <Link
+          key={l.href}
+          href={l.href}
+          className={clsx('px-3 py-2', pathname === l.href && 'font-semibold')}
+        >
+          {l.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- add admin navigation bar component
- enforce admin authentication and include nav via layout

## Testing
- `npm run lint` *(fails: next: not found)*
- `npm run typecheck` *(fails: missing module types)*

------
https://chatgpt.com/codex/tasks/task_e_68b23a38fc78832b99ffb7b4dc3d2144