### PR TITLE
Add moto creation and edit pages in admin

### DIFF
--- a/src/app/admin/motos/[id]/edit/page.tsx
+++ b/src/app/admin/motos/[id]/edit/page.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link';
+import { createClient } from '@/utils/supabase/server';
+import { updateMoto } from '../../actions';
+
+export default async function EditMoto({params}:{params:{id:string}}){
+  const s=await createClient();
+  const {data:m}=await s.from('motos').select('*').eq('id',params.id).single();
+  if(!m) return <div className="p-6">Introuvable</div>;
+  return(<div className="p-6 max-w-2xl space-y-6">
+    <div className="flex items-center justify-between">
+      <h1 className="text-xl font-semibold">Éditer : {m.brand} {m.model}</h1>
+      <div className="flex gap-4">
+        <Link href={`/admin/motos/${m.id}/specs`} className="underline">Specs</Link>
+        <Link href={`/admin/motos/${m.id}/images`} className="underline">Images</Link>
+      </div>
+    </div>
+    <form action={async(fd)=>{'use server';await updateMoto(m.id,fd);}} className="grid grid-cols-2 gap-3">
+      <input name="brand" defaultValue={m.brand||''} className="border p-2 rounded" placeholder="Marque"/>
+      <input name="model" defaultValue={m.model||''} className="border p-2 rounded" placeholder="Modèle"/>
+      <input name="year"  defaultValue={m.year||''} className="border p-2 rounded" placeholder="Année" type="number"/>
+      <input name="price" defaultValue={m.price||''} className="border p-2 rounded" placeholder="Prix" type="number" step="0.01"/>
+      <input name="main_image_url" defaultValue={m.main_image_url||''} className="col-span-2 border p-2 rounded" placeholder="Image principale (URL)"/>
+      <label className="col-span-2 flex items-center gap-2"><input type="checkbox" name="is_published" defaultChecked={m.is_published}/> Publiée</label>
+      <div className="col-span-2"><button className="border px-3 py-2 rounded">Enregistrer</button></div>
+    </form>
+  </div>);
+}

--- a/src/app/admin/motos/actions.ts
+++ b/src/app/admin/motos/actions.ts
@@ -1,14 +1,30 @@
 'use server';
+import { redirect } from 'next/navigation';
 import { revalidatePath } from 'next/cache';
 import { createClient } from '@/utils/supabase/server';
 
-export async function togglePublish(id:string,current:boolean){
+const b=(v:FormDataEntryValue|null)=>v==='on'||v==='true'||v==='1';
+
+export async function createMoto(fd:FormData){
   const s=await createClient();
-  const {error}=await s.from('motos').update({is_published:!current}).eq('id',id);
+  const row={brand:String(fd.get('brand')||'').trim(),model:String(fd.get('model')||'').trim(),
+    year:Number(fd.get('year')||0)||null,price:Number(fd.get('price')||0)||null,is_published:b(fd.get('is_published'))};
+  const {data,error}=await s.from('motos').insert(row).select('id').single();
+  if(error) throw error; redirect(`/admin/motos/${data!.id}/edit`);
+}
+export async function updateMoto(id:string,fd:FormData){
+  const s=await createClient();
+  const patch:any={brand:String(fd.get('brand')||'').trim(),model:String(fd.get('model')||'').trim(),
+    year:Number(fd.get('year')||0)||null,price:Number(fd.get('price')||0)||null,
+    is_published:b(fd.get('is_published')),main_image_url:String(fd.get('main_image_url')||'').trim()||null};
+  const {error}=await s.from('motos').update(patch).eq('id',id);
+  if(error) throw error; revalidatePath(`/admin/motos/${id}/edit`);
+}
+export async function togglePublish(id:string,current:boolean){
+  const s=await createClient(); const {error}=await s.from('motos').update({is_published:!current}).eq('id',id);
   if(error) throw error; revalidatePath('/admin/motos');
 }
 export async function deleteMoto(id:string){
-  const s=await createClient();
-  const {error}=await s.from('motos').delete().eq('id',id);
+  const s=await createClient(); const {error}=await s.from('motos').delete().eq('id',id);
   if(error) throw error; revalidatePath('/admin/motos');
 }

--- a/src/app/admin/motos/new/page.tsx
+++ b/src/app/admin/motos/new/page.tsx
@@ -1,0 +1,14 @@
+import { createMoto } from '../actions';
+export default function NewMoto(){
+  return(<div className="p-6 max-w-xl">
+    <h1 className="text-xl font-semibold mb-4">Nouvelle moto</h1>
+    <form action={createMoto} className="space-y-3">
+      <input name="brand" className="w-full border p-2 rounded" placeholder="Marque" required />
+      <input name="model" className="w-full border p-2 rounded" placeholder="Modèle" required />
+      <input name="year"  className="w-full border p-2 rounded" placeholder="Année" type="number" min="1900" />
+      <input name="price" className="w-full border p-2 rounded" placeholder="Prix" type="number" step="0.01" />
+      <label className="flex items-center gap-2"><input type="checkbox" name="is_published" /> Publier</label>
+      <button className="border px-3 py-2 rounded">Créer</button>
+    </form>
+  </div>);
+}


### PR DESCRIPTION
## Summary
- support creating new motos
- add editing page for motos
- extend server actions for creating and updating

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: next not found)
- `npm ci` (fails: 403 Forbidden fetching package)
- `npm run typecheck` (fails: multiple missing module errors)


------
https://chatgpt.com/codex/tasks/task_e_68b257acefd4832ba383523e54389553