### PR TITLE
feat: manage moto specs and images in admin

### DIFF
--- a/src/app/admin/motos/[id]/images/page.tsx
+++ b/src/app/admin/motos/[id]/images/page.tsx
@@ -1,0 +1,34 @@
+import { createClient } from '@/utils/supabase/server';
+import { uploadImage, setMainImage, deleteImage } from '../../actions';
+
+export default async function ImagesPage({params}:{params:{id:string}}){
+  const s=await createClient();
+  const {data:imgs}=await s.from('moto_images')
+    .select('id,image_url,alt,is_main').eq('moto_id',params.id)
+    .order('created_at',{ascending:false});
+  return(<div className="p-6 space-y-6">
+    <h1 className="text-xl font-semibold">Images</h1>
+    <form action={async(fd)=>{'use server';await uploadImage(params.id,fd);}} className="flex items-center gap-2">
+      <input type="file" name="file" required/>
+      <input type="text" name="alt" placeholder="Alt" className="border p-2 rounded"/>
+      <label className="flex items-center gap-2"><input type="checkbox" name="make_main"/> Définir principale</label>
+      <button className="border px-3 py-2 rounded">Uploader</button>
+    </form>
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      {imgs?.map((im:any)=>(
+        <div key={im.id} className="border rounded p-2">
+          <img src={im.image_url} alt={im.alt||''} className="w-full h-32 object-cover rounded"/>
+          <div className="flex items-center justify-between mt-2 text-sm">
+            <span>{im.is_main?'★ Principale':''}</span>
+            <div className="flex gap-3">
+              {!im.is_main&&(<form action={async()=>{'use server';await setMainImage(im.id,params.id);}}>
+                <button className="underline">Définir</button></form>)}
+              <form action={async()=>{'use server';await deleteImage(im.id,params.id);}}>
+                <button className="underline text-red-600">Supprimer</button></form>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  </div>);
+}

--- a/src/app/admin/motos/[id]/specs/page.tsx
+++ b/src/app/admin/motos/[id]/specs/page.tsx
@@ -1,0 +1,34 @@
+import { createClient } from '@/utils/supabase/server';
+import { addSpec, deleteSpec } from '../../actions';
+
+export default async function SpecsPage({params}:{params:{id:string}}){
+  const s=await createClient();
+  const {data:specs}=await s.from('moto_specs')
+    .select('id,category,subcategory,key_name,value_text,unit,sort_order')
+    .eq('moto_id',params.id).order('sort_order',{ascending:true});
+  return(<div className="p-6">
+    <h1 className="text-xl font-semibold mb-4">Caractéristiques</h1>
+    <form action={async(fd)=>{'use server';await addSpec(params.id,fd);}} className="grid grid-cols-6 gap-2 mb-6">
+      <input name="category" className="border p-2 rounded" placeholder="Catégorie"/>
+      <input name="subcategory" className="border p-2 rounded" placeholder="Sous-catégorie"/>
+      <input name="key_name" className="border p-2 rounded" placeholder="Nom" required/>
+      <input name="value_text" className="border p-2 rounded" placeholder="Valeur" required/>
+      <input name="unit" className="border p-2 rounded" placeholder="Unité"/>
+      <input name="sort_order" type="number" className="border p-2 rounded" placeholder="Ordre"/>
+      <div className="col-span-6"><button className="border px-3 py-2 rounded">+ Ajouter</button></div>
+    </form>
+    <table className="w-full text-sm">
+      <thead><tr><th>Cat.</th><th>Sous-cat.</th><th>Nom</th><th>Valeur</th><th>Unité</th><th>Ordre</th><th>Actions</th></tr></thead>
+      <tbody>{specs?.map((sp:any)=>(
+        <tr key={sp.id} className="border-t">
+          <td>{sp.category||'-'}</td><td>{sp.subcategory||'-'}</td>
+          <td>{sp.key_name}</td><td>{sp.value_text}</td><td>{sp.unit||'-'}</td><td>{sp.sort_order||0}</td>
+          <td className="py-2">
+            <form action={async()=>{'use server';await deleteSpec(sp.id,params.id);}}>
+              <button className="underline text-red-600">Supprimer</button>
+            </form>
+          </td>
+        </tr>))}</tbody>
+    </table>
+  </div>);
+}

--- a/src/app/admin/motos/actions.ts
+++ b/src/app/admin/motos/actions.ts
@@ -2,29 +2,59 @@
 import { redirect } from 'next/navigation';
 import { revalidatePath } from 'next/cache';
 import { createClient } from '@/utils/supabase/server';
-
 const b=(v:FormDataEntryValue|null)=>v==='on'||v==='true'||v==='1';
 
-export async function createMoto(fd:FormData){
-  const s=await createClient();
+export async function createMoto(fd:FormData){ const s=await createClient();
   const row={brand:String(fd.get('brand')||'').trim(),model:String(fd.get('model')||'').trim(),
     year:Number(fd.get('year')||0)||null,price:Number(fd.get('price')||0)||null,is_published:b(fd.get('is_published'))};
   const {data,error}=await s.from('motos').insert(row).select('id').single();
-  if(error) throw error; redirect(`/admin/motos/${data!.id}/edit`);
-}
-export async function updateMoto(id:string,fd:FormData){
-  const s=await createClient();
+  if(error) throw error; redirect(`/admin/motos/${data!.id}/edit`); }
+
+export async function updateMoto(id:string,fd:FormData){ const s=await createClient();
   const patch:any={brand:String(fd.get('brand')||'').trim(),model:String(fd.get('model')||'').trim(),
     year:Number(fd.get('year')||0)||null,price:Number(fd.get('price')||0)||null,
     is_published:b(fd.get('is_published')),main_image_url:String(fd.get('main_image_url')||'').trim()||null};
   const {error}=await s.from('motos').update(patch).eq('id',id);
-  if(error) throw error; revalidatePath(`/admin/motos/${id}/edit`);
-}
-export async function togglePublish(id:string,current:boolean){
-  const s=await createClient(); const {error}=await s.from('motos').update({is_published:!current}).eq('id',id);
-  if(error) throw error; revalidatePath('/admin/motos');
-}
-export async function deleteMoto(id:string){
-  const s=await createClient(); const {error}=await s.from('motos').delete().eq('id',id);
-  if(error) throw error; revalidatePath('/admin/motos');
-}
+  if(error) throw error; revalidatePath(`/admin/motos/${id}/edit`); }
+
+export async function togglePublish(id:string,current:boolean){ const s=await createClient();
+  const {error}=await s.from('motos').update({is_published:!current}).eq('id',id);
+  if(error) throw error; revalidatePath('/admin/motos'); }
+
+export async function deleteMoto(id:string){ const s=await createClient();
+  const {error}=await s.from('motos').delete().eq('id',id);
+  if(error) throw error; revalidatePath('/admin/motos'); }
+
+/* SPECS */
+export async function addSpec(motoId:string,fd:FormData){ const s=await createClient();
+  const row={moto_id:motoId,category:String(fd.get('category')||'').trim()||null,
+    subcategory:String(fd.get('subcategory')||'').trim()||null,key_name:String(fd.get('key_name')||'').trim(),
+    value_text:String(fd.get('value_text')||'').trim(),unit:String(fd.get('unit')||'').trim()||null,
+    sort_order:Number(fd.get('sort_order')||0)||0};
+  const {error}=await s.from('moto_specs').insert(row); if(error) throw error;
+  revalidatePath(`/admin/motos/${motoId}/specs`); }
+
+export async function deleteSpec(specId:string,motoId:string){ const s=await createClient();
+  const {error}=await s.from('moto_specs').delete().eq('id',specId); if(error) throw error;
+  revalidatePath(`/admin/motos/${motoId}/specs`); }
+
+/* IMAGES */
+export async function uploadImage(motoId:string,fd:FormData){
+  const s=await createClient();
+  const file=fd.get('file') as File|null;
+  const alt=String(fd.get('alt')||'').trim()||null;
+  const makeMain=b(fd.get('make_main'));
+  if(!file) throw new Error('Aucun fichier');
+  const path=`motos/${motoId}/${Date.now()}-${file.name}`;
+  const {error:up}=await s.storage.from('motos').upload(path,file,{upsert:false}); if(up) throw up;
+  const {data:pub}=s.storage.from('motos').getPublicUrl(path);
+  const {error}=await s.from('moto_images').insert({moto_id:motoId,image_url:pub.publicUrl,alt,is_main:makeMain});
+  if(error) throw error; revalidatePath(`/admin/motos/${motoId}/images`); }
+
+export async function setMainImage(imgId:string,motoId:string){ const s=await createClient();
+  const {error}=await s.from('moto_images').update({is_main:true}).eq('id',imgId);
+  if(error) throw error; revalidatePath(`/admin/motos/${motoId}/images`); }
+
+export async function deleteImage(imgId:string,motoId:string){ const s=await createClient();
+  const {error}=await s.from('moto_images').delete().eq('id',imgId);
+  if(error) throw error; revalidatePath(`/admin/motos/${motoId}/images`); }


### PR DESCRIPTION
## Summary
- extend moto server actions with spec and image helpers
- add admin pages to manage moto specifications and images

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: numerous TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b258de8040832b97368ad0780990e8