### PR TITLE
feat: add Supabase motos pages

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    serverActions: true,
-  },
   images: {
     remotePatterns: [
       { protocol: 'https', hostname: '**' },

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  experimental: {
+    serverActions: true,
+  },
   images: {
     remotePatterns: [
       { protocol: 'https', hostname: '**' },

--- a/src/app/motos/[id]/page.tsx
+++ b/src/app/motos/[id]/page.tsx
@@ -136,7 +136,6 @@ export default async function MotoPage({ params }: Params) {
 
       {mainImage && (
         <div className="relative w-full max-w-3xl aspect-video bg-gray-100 rounded-xl overflow-hidden mb-6">
-          {/* @ts-expect-error Next/Image runtime config */}
           <Image src={mainImage} alt={`${moto.brand} ${moto.model}`} fill className="object-contain" />
         </div>
       )}
@@ -145,7 +144,6 @@ export default async function MotoPage({ params }: Params) {
         <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-8">
           {images!.map(im => (
             <div key={im.id} className="relative w-full aspect-square bg-gray-100 rounded-lg overflow-hidden">
-              {/* @ts-expect-error Next/Image runtime config */}
               <Image src={im.image_url ?? ''} alt={im.alt ?? `${moto.brand} ${moto.model}`} fill className="object-cover" />
             </div>
           ))}

--- a/src/app/motos/[id]/page.tsx
+++ b/src/app/motos/[id]/page.tsx
@@ -13,48 +13,49 @@ type Moto = {
   id: string;
   brand: string;
   model: string;
-  year?: number | null;
-  price_tnd?: number | null;
-  main_image_url?: string | null;
-  status?: string | null;
-  warranty?: string | null;
-  dealer_name?: string | null;
+  year: number | null;
+  price: number | null;             // "price" NUMERIC
+  main_image_url: string | null;    // image principale possible
+  is_published: boolean | null;
+  slug: string | null;
 };
 
-type MotoSpec = {
+type MotoSpecRow = {
   id: string;
   moto_id: string;
-  group_name: string | null;
-  label: string;
-  value: string;
-  sort_index?: number | null;
+  category: string | null;
+  subcategory: string | null;
+  key_name: string | null;     // -> label
+  value_text: string | null;   // -> value
+  unit: string | null;
+  sort_order: number | null;   // tri
 };
 
 type MotoImage = {
   id: string;
   moto_id: string;
-  url: string;
+  image_url: string | null;
   alt: string | null;
-  sort_index: number | null;
+  is_main: boolean | null;
+  created_at: string | null;
 };
-
-function stripLeadingLabel(label: string, value: string) {
-  const l = label.trim().toLowerCase();
-  const v = value.trim();
-  if (v.toLowerCase().startsWith(l)) {
-    const rest = v.slice(label.length).trim().replace(/^[:\-]/, '').trim();
-    return rest || value;
-  }
-  return value;
-}
 
 function moneyTND(n?: number | null) {
   if (n == null) return '';
   try {
     return new Intl.NumberFormat('fr-TN', { style: 'currency', currency: 'TND', maximumFractionDigits: 0 }).format(n);
-  } catch {
-    return `${n} TND`;
+  } catch { return `${n} TND`; }
+}
+
+function stripLeadingLabel(label?: string | null, value?: string | null) {
+  const l = (label ?? '').trim().toLowerCase();
+  const v = (value ?? '').trim();
+  if (!l || !v) return v;
+  if (v.toLowerCase().startsWith(l)) {
+    const rest = v.slice(label!.length).trim().replace(/^[:\-]/, '').trim();
+    return rest || v;
   }
+  return v;
 }
 
 export async function generateMetadata({ params }: Params): Promise<Metadata> {
@@ -73,10 +74,10 @@ export default async function MotoPage({ params }: Params) {
   const id = params.id;
   const supabase = supabaseServer();
 
-  // IMPORTANT: NE PAS importer de données locales. Lecture 100% Supabase.
+  // 1) Fiche principale
   const { data: moto, error: eMoto } = await supabase
     .from('motos')
-    .select('id, brand, model, year, price_tnd, main_image_url, status, warranty, dealer_name')
+    .select('id, brand, model, year, price, main_image_url, is_published, slug')
     .eq('id', id)
     .maybeSingle();
 
@@ -90,38 +91,38 @@ export default async function MotoPage({ params }: Params) {
     );
   }
 
+  // 2) Specs + Images
   const [{ data: specs }, { data: images }] = await Promise.all([
     supabase
       .from('moto_specs')
-      .select('id, moto_id, group_name, label, value, sort_index')
+      .select('id, moto_id, category, subcategory, key_name, value_text, unit, sort_order')
       .eq('moto_id', id)
-      .order('group_name', { ascending: true })
-      .order('sort_index', { ascending: true }),
+      .order('subcategory', { ascending: true, nullsFirst: true })
+      .order('category', { ascending: true, nullsFirst: true })
+      .order('sort_order', { ascending: true, nullsFirst: true }),
     supabase
       .from('moto_images')
-      .select('id, moto_id, url, alt, sort_index')
+      .select('id, moto_id, image_url, alt, is_main, created_at')
       .eq('moto_id', id)
-      .order('sort_index', { ascending: true }),
+      .order('is_main', { ascending: false, nullsFirst: false })
+      .order('created_at', { ascending: true, nullsFirst: true }),
   ]);
 
-  // Dé-doublonnage UI (sécurité supplémentaire)
-  const uniqueSpecs: MotoSpec[] = [];
-  const seen = new Set<string>();
-  (specs ?? []).forEach(s => {
-    const group = (s.group_name ?? 'Spécifications').trim();
-    const cleanVal = stripLeadingLabel(s.label, s.value);
-    const key = `${s.moto_id}|${group}|${s.label.trim()}|${cleanVal}|${s.sort_index ?? ''}`;
-    if (!seen.has(key)) {
-      seen.add(key);
-      uniqueSpecs.push({ ...s, group_name: group, value: cleanVal });
-    }
-  });
+  // Détermination de l'image principale
+  const mainImage =
+    moto.main_image_url ||
+    (images?.find(im => im.is_main && im.image_url)?.image_url ?? images?.[0]?.image_url ?? null);
 
-  // Regrouper par groupe
-  const groups = new Map<string, MotoSpec[]>();
-  uniqueSpecs.forEach(s => {
-    if (!groups.has(s.group_name!)) groups.set(s.group_name!, []);
-    groups.get(s.group_name!)!.push(s);
+  // Regrouper specs par groupe = subcategory > category > "Spécifications"
+  type UIItem = { id: string; label: string; value: string };
+  const groups = new Map<string, UIItem[]>();
+  (specs ?? []).forEach(s => {
+    const group = (s.subcategory || s.category || 'Spécifications').trim();
+    const label = (s.key_name ?? '').trim();
+    let value = stripLeadingLabel(s.key_name, s.value_text);
+    if (s.unit && value) value = `${value} ${s.unit}`.trim();
+    if (!groups.has(group)) groups.set(group, []);
+    groups.get(group)!.push({ id: s.id, label, value: value ?? '' });
   });
 
   return (
@@ -129,20 +130,14 @@ export default async function MotoPage({ params }: Params) {
       <div className="mb-6">
         <h1 className="text-3xl font-bold">{moto.brand} {moto.model}</h1>
         <p className="text-sm text-muted-foreground">
-          {moto.year ? `Année ${moto.year} · ` : ''}{moto.price_tnd ? moneyTND(Number(moto.price_tnd)) : ''}
+          {moto.year ? `Année ${moto.year} · ` : ''}{moto.price ? moneyTND(Number(moto.price)) : ''}
         </p>
-        {(moto.status || moto.warranty || moto.dealer_name) && (
-          <div className="mt-2 text-sm text-muted-foreground">
-            {moto.status && <span className="mr-3">Statut: {moto.status}</span>}
-            {moto.warranty && <span className="mr-3">Garantie: {moto.warranty}</span>}
-            {moto.dealer_name && <span className="mr-3">Distributeur: {moto.dealer_name}</span>}
-          </div>
-        )}
       </div>
 
-      {moto.main_image_url && (
+      {mainImage && (
         <div className="relative w-full max-w-3xl aspect-video bg-gray-100 rounded-xl overflow-hidden mb-6">
-          <Image src={moto.main_image_url} alt={`${moto.brand} ${moto.model}`} fill className="object-contain" />
+          {/* @ts-expect-error Next/Image runtime config */}
+          <Image src={mainImage} alt={`${moto.brand} ${moto.model}`} fill className="object-contain" />
         </div>
       )}
 
@@ -150,7 +145,8 @@ export default async function MotoPage({ params }: Params) {
         <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-8">
           {images!.map(im => (
             <div key={im.id} className="relative w-full aspect-square bg-gray-100 rounded-lg overflow-hidden">
-              <Image src={im.url} alt={im.alt ?? `${moto.brand} ${moto.model}`} fill className="object-cover" />
+              {/* @ts-expect-error Next/Image runtime config */}
+              <Image src={im.image_url ?? ''} alt={im.alt ?? `${moto.brand} ${moto.model}`} fill className="object-cover" />
             </div>
           ))}
         </div>
@@ -172,3 +168,4 @@ export default async function MotoPage({ params }: Params) {
     </div>
   );
 }
+

--- a/src/app/motos/page.tsx
+++ b/src/app/motos/page.tsx
@@ -1,45 +1,60 @@
 import Link from 'next/link';
 import Image from 'next/image';
-import { getPublishedMotos } from '@/lib/public/motos';
+import { supabaseServer } from '@/lib/supabase/server';
 
+export const revalidate = 0;
 export const dynamic = 'force-dynamic';
+export const fetchCache = 'force-no-store';
 
-export default async function MotosPublicList() {
-  const rows = await getPublishedMotos();
+type MotoPub = {
+  id: string;
+  brand: string;
+  model: string;
+  year: number | null;
+  price: number | null;            // numeric
+  slug: string | null;
+  display_image: string | null;    // image URL à afficher
+};
+
+function moneyTND(n?: number | null) {
+  if (n == null) return '';
+  try {
+    return new Intl.NumberFormat('fr-TN', { style: 'currency', currency: 'TND', maximumFractionDigits: 0 }).format(n);
+  } catch { return `${n} TND`; }
+}
+
+export default async function MotosPage() {
+  const supabase = supabaseServer();
+  const { data: motos, error } = await supabase
+    .from('motos_public')
+    .select('id, brand, model, year, price, slug, display_image')
+    .order('brand', { ascending: true })
+    .order('model', { ascending: true });
+
+  if (error) console.error('Erreur lecture motos_public:', error);
+
   return (
-    <main className="p-6">
-      <h1 className="text-2xl font-semibold mb-6">Motos neuves</h1>
-      {!rows.length && <p>Aucune moto publiée pour le moment.</p>}
-      <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3">
-        {rows.map(m => (
-          <Link
-            key={m.id}
-            href={`/motos/${m.slug || m.id}`}
-            className="border rounded overflow-hidden hover:shadow"
-          >
-            <div className="aspect-[4/3] bg-black/10 relative">
+    <div className="max-w-6xl mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-6">Motos neuves</h1>
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        {(motos ?? []).map(m => (
+          <Link key={m.id} href={`/motos/${m.id}`} className="rounded-xl border p-3 hover:shadow">
+            <div className="relative w-full aspect-video bg-gray-100 rounded-lg overflow-hidden mb-2">
               {m.display_image ? (
-                <Image
-                  src={m.display_image}
-                  alt={`${m.brand || ''} ${m.model || ''}`}
-                  fill
-                  sizes="(max-width:768px) 100vw, 33vw"
-                  className="object-cover"
-                />
+                // @ts-expect-error Next/Image runtime
+                <Image src={m.display_image} alt={`${m.brand} ${m.model}`} fill className="object-cover" />
               ) : (
-                <div className="w-full h-full grid place-items-center text-sm text-white/60">
-                  Pas d’image
-                </div>
+                <div className="w-full h-full grid place-items-center text-xs text-gray-500">Pas d’image</div>
               )}
             </div>
-            <div className="p-3 text-sm">
-              <div className="font-medium">{m.brand} {m.model}</div>
-              <div className="opacity-70">{m.year ?? ''} {m.price ? `• ${m.price} TND` : ''}</div>
+            <div className="text-sm font-semibold">{m.brand} {m.model}</div>
+            <div className="text-xs text-gray-600">
+              {m.year ? `${m.year} • ` : ''}{m.price ? moneyTND(Number(m.price)) : ''}
             </div>
           </Link>
         ))}
       </div>
-    </main>
+    </div>
   );
 }
 

--- a/src/app/motos/page.tsx
+++ b/src/app/motos/page.tsx
@@ -41,7 +41,6 @@ export default async function MotosPage() {
           <Link key={m.id} href={`/motos/${m.id}`} className="rounded-xl border p-3 hover:shadow">
             <div className="relative w-full aspect-video bg-gray-100 rounded-lg overflow-hidden mb-2">
               {m.display_image ? (
-                // @ts-expect-error Next/Image runtime
                 <Image src={m.display_image} alt={`${m.brand} ${m.model}`} fill className="object-cover" />
               ) : (
                 <div className="w-full h-full grid place-items-center text-xs text-gray-500">Pas d’image</div>


### PR DESCRIPTION
## Summary
- list motos from `motos_public` with no caching and dynamic links
- add detailed moto page pulling specs and images from Supabase
- allow external image domains in Next.js config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b3153e05a8832b8fbf05f8685cdf5b