### PR TITLE
feat: connect motos pages to Supabase data

### DIFF
--- a/src/app/motos/[id]/page.tsx
+++ b/src/app/motos/[id]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Image from 'next/image';
-import { supabaseServer } from '@/lib/supabase/server';
+import { fetchMotoFull } from '@/services/motos';
+import { publicImageUrl } from '@/lib/storage';
 
 export const revalidate = 0;
 export const dynamic = 'force-dynamic';
@@ -9,155 +10,90 @@ export const dynamicParams = true;
 
 type Params = { params: { id: string } };
 
-type Moto = {
-  id: string;
-  brand: string;
-  model: string;
-  year: number | null;
-  price: number | null;             // "price" NUMERIC
-  main_image_url: string | null;    // image principale possible
-  is_published: boolean | null;
-  slug: string | null;
-};
-
-type MotoSpecRow = {
-  id: string;
-  moto_id: string;
-  category: string | null;
-  subcategory: string | null;
-  key_name: string | null;     // -> label
-  value_text: string | null;   // -> value
-  unit: string | null;
-  sort_order: number | null;   // tri
-};
-
-type MotoImage = {
-  id: string;
-  moto_id: string;
-  image_url: string | null;
-  alt: string | null;
-  is_main: boolean | null;
-  created_at: string | null;
-};
-
 function moneyTND(n?: number | null) {
   if (n == null) return '';
   try {
     return new Intl.NumberFormat('fr-TN', { style: 'currency', currency: 'TND', maximumFractionDigits: 0 }).format(n);
-  } catch { return `${n} TND`; }
-}
-
-function stripLeadingLabel(label?: string | null, value?: string | null) {
-  const l = (label ?? '').trim().toLowerCase();
-  const v = (value ?? '').trim();
-  if (!l || !v) return v;
-  if (v.toLowerCase().startsWith(l)) {
-    const rest = v.slice(label!.length).trim().replace(/^[:\-]/, '').trim();
-    return rest || v;
+  } catch {
+    return `${n} TND`;
   }
-  return v;
 }
 
 export async function generateMetadata({ params }: Params): Promise<Metadata> {
-  const supabase = supabaseServer();
-  const { data } = await supabase
-    .from('motos')
-    .select('brand, model, year')
-    .eq('id', params.id)
-    .maybeSingle();
-
+  const data = await fetchMotoFull(params.id).catch(() => null);
   const title = data ? `${data.brand} ${data.model} | moto.tn` : 'Fiche moto | moto.tn';
   return { title };
 }
 
 export default async function MotoPage({ params }: Params) {
-  const id = params.id;
-  const supabase = supabaseServer();
+  let data: any = null;
+  try {
+    data = await fetchMotoFull(params.id);
+  } catch (error) {
+    console.error('Erreur fn_get_moto_full:', error);
+  }
 
-  // 1) Fiche principale
-  const { data: moto, error: eMoto } = await supabase
-    .from('motos')
-    .select('id, brand, model, year, price, main_image_url, is_published, slug')
-    .eq('id', id)
-    .maybeSingle();
-
-  if (eMoto) console.error('Erreur moto:', eMoto);
-  if (!moto) {
+  if (!data) {
     return (
       <div className="max-w-5xl mx-auto px-4 py-10">
-        <h1 className="text-2xl font-bold">Fiche introuvable</h1>
+        <h1 className="text-2xl font-bold">Fiche indisponible</h1>
         <p className="mt-2 text-muted-foreground">La moto demandée n’existe pas ou a été supprimée.</p>
       </div>
     );
   }
 
-  // 2) Specs + Images
-  const [{ data: specs }, { data: images }] = await Promise.all([
-    supabase
-      .from('moto_specs')
-      .select('id, moto_id, category, subcategory, key_name, value_text, unit, sort_order')
-      .eq('moto_id', id)
-      .order('subcategory', { ascending: true, nullsFirst: true })
-      .order('category', { ascending: true, nullsFirst: true })
-      .order('sort_order', { ascending: true, nullsFirst: true }),
-    supabase
-      .from('moto_images')
-      .select('id, moto_id, image_url, alt, is_main, created_at')
-      .eq('moto_id', id)
-      .order('is_main', { ascending: false, nullsFirst: false })
-      .order('created_at', { ascending: true, nullsFirst: true }),
-  ]);
-
-  // Détermination de l'image principale
-  const mainImage =
-    moto.main_image_url ||
-    (images?.find(im => im.is_main && im.image_url)?.image_url ?? images?.[0]?.image_url ?? null);
-
-  // Regrouper specs par groupe = subcategory > category > "Spécifications"
-  type UIItem = { id: string; label: string; value: string };
-  const groups = new Map<string, UIItem[]>();
-  (specs ?? []).forEach(s => {
-    const group = (s.subcategory || s.category || 'Spécifications').trim();
-    const label = (s.key_name ?? '').trim();
-    let value = stripLeadingLabel(s.key_name, s.value_text);
-    if (s.unit && value) value = `${value} ${s.unit}`.trim();
-    if (!groups.has(group)) groups.set(group, []);
-    groups.get(group)!.push({ id: s.id, label, value: value ?? '' });
-  });
+  const images = (data.images ?? []).sort((a: any, b: any) =>
+    (Number(b.is_primary) - Number(a.is_primary)) || ((a.sort_order ?? 0) - (b.sort_order ?? 0))
+  );
+  const groups = data.groups ?? [];
 
   return (
     <div className="max-w-5xl mx-auto px-4 py-8">
       <div className="mb-6">
-        <h1 className="text-3xl font-bold">{moto.brand} {moto.model}</h1>
+        <h1 className="text-3xl font-bold">{data.brand} {data.model}</h1>
         <p className="text-sm text-muted-foreground">
-          {moto.year ? `Année ${moto.year} · ` : ''}{moto.price ? moneyTND(Number(moto.price)) : ''}
+          {data.year ? `Année ${data.year} · ` : ''}{data.price ? moneyTND(Number(data.price)) : ''}
         </p>
       </div>
 
-      {mainImage && (
+      {publicImageUrl(images[0]?.path) && (
         <div className="relative w-full max-w-3xl aspect-video bg-gray-100 rounded-xl overflow-hidden mb-6">
-          <Image src={mainImage} alt={`${moto.brand} ${moto.model}`} fill className="object-contain" />
+          <Image
+            src={publicImageUrl(images[0].path)!}
+            alt={images[0].alt ?? `${data.brand} ${data.model}`}
+            fill
+            className="object-contain"
+          />
         </div>
       )}
 
-      {(images?.length ?? 0) > 0 && (
+      {images.length > 1 && (
         <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-8">
-          {images!.map(im => (
-            <div key={im.id} className="relative w-full aspect-square bg-gray-100 rounded-lg overflow-hidden">
-              <Image src={im.image_url ?? ''} alt={im.alt ?? `${moto.brand} ${moto.model}`} fill className="object-cover" />
+          {images.map((img: any, idx: number) => (
+            <div key={idx} className="relative w-full aspect-square bg-gray-100 rounded-lg overflow-hidden">
+              {publicImageUrl(img.path) && (
+                <Image
+                  src={publicImageUrl(img.path)!}
+                  alt={img.alt ?? `${data.brand} ${data.model}`}
+                  fill
+                  className="object-cover"
+                />
+              )}
             </div>
           ))}
         </div>
       )}
 
-      {[...groups.entries()].map(([group, items]) => (
-        <div key={group} className="mb-6">
-          <h2 className="text-xl font-semibold mb-3">{group}</h2>
+      {groups.map((g: any) => (
+        <div key={g.group} className="mb-6">
+          <h2 className="text-xl font-semibold mb-3">{g.group}</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-            {items.map(it => (
-              <div key={it.id} className="rounded-lg border p-3">
-                <div className="text-sm font-medium">{it.label}</div>
-                <div className="text-sm text-muted-foreground">{it.value}</div>
+            {(g.items ?? []).filter((it: any) => it.value).map((it: any, idx: number) => (
+              <div key={idx} className="rounded-lg border p-3">
+                <div className="text-sm font-medium">{it.key}</div>
+                <div className="text-sm text-muted-foreground">
+                  {it.value}{it.unit ? ` ${it.unit}` : ''}
+                </div>
               </div>
             ))}
           </div>
@@ -166,4 +102,3 @@ export default async function MotoPage({ params }: Params) {
     </div>
   );
 }
-

--- a/src/app/motos/page.tsx
+++ b/src/app/motos/page.tsx
@@ -2,20 +2,11 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { fetchMotoCards } from '@/services/motos';
 import { publicImageUrl } from '@/lib/storage';
+import type { MotoCard } from '@/types/supabase';
 
 export const revalidate = 0;
 export const dynamic = 'force-dynamic';
 export const fetchCache = 'force-no-store';
-
-type MotoCard = {
-  id: string;
-  brand: string;
-  model: string;
-  year: number | null;
-  price: number | null;
-  slug: string | null;
-  image_path: string | null;
-};
 
 function moneyTND(n?: number | null) {
   if (n == null) return '';

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,5 @@
+export function publicImageUrl(path?: string | null) {
+  if (!path) return null;
+  const base = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  return `${base}/storage/v1/object/public/${path}`;
+}

--- a/src/services/motos.ts
+++ b/src/services/motos.ts
@@ -1,0 +1,19 @@
+import { supabase } from '@/lib/supabaseClient';
+import type { MotoCard, MotoFull } from '@/types/supabase';
+
+export async function fetchMotoCards(): Promise<MotoCard[]> {
+  const { data, error } = await supabase
+    .from('v_moto_cards')
+    .select('*')
+    .order('year', { ascending: false })
+    .limit(2000);
+  if (error) throw error;
+  return (data as MotoCard[]) ?? [];
+}
+
+export async function fetchMotoFull(id: string): Promise<MotoFull | null> {
+  const { data, error } = await supabase
+    .rpc('fn_get_moto_full', { p_moto_id: id });
+  if (error) throw error;
+  return data as MotoFull | null;
+}

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -1,0 +1,38 @@
+export interface MotoCard {
+  id: string;
+  brand: string | null;
+  model: string | null;
+  year: number | null;
+  price: number | null;
+  image_path: string | null;
+  slug: string | null;
+}
+
+export interface MotoImage {
+  path: string | null;
+  alt: string | null;
+  is_primary: boolean | null;
+  sort_order: number | null;
+}
+
+export interface MotoGroupItem {
+  key: string | null;
+  value: string | null;
+  unit: string | null;
+}
+
+export interface MotoGroup {
+  group: string | null;
+  items: MotoGroupItem[];
+}
+
+export interface MotoFull {
+  id: string;
+  brand: string | null;
+  model: string | null;
+  year: number | null;
+  price: number | null;
+  images?: MotoImage[];
+  groups?: MotoGroup[];
+  slug?: string | null;
+}


### PR DESCRIPTION
## Summary
- add storage helper for public Supabase images
- load moto cards from Supabase view and expose RPC detail fetcher
- build storage URLs and sort images by primary then order
- add flexible types for Supabase payloads

## Testing
- `npm run lint` *(fails: next: not found)*
- `npm run typecheck` *(fails: Cannot find module '@supabase/ssr' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b36535a388832bbe2944925a6375bd