### PR TITLE
feat: connect motos pages to Supabase backend

### DIFF
--- a/src/app/motos/[id]/loading.tsx
+++ b/src/app/motos/[id]/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-8">
+      <p className="text-sm text-muted-foreground">Chargement...</p>
+    </div>
+  );
+}

--- a/src/app/motos/[id]/page.tsx
+++ b/src/app/motos/[id]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import Image from 'next/image';
-import { fetchMotoFull } from '@/services/motos';
+import { fetchMotoFullBySlugOrId } from '@/services/motos';
 import { publicImageUrl } from '@/lib/storage';
 
 export const revalidate = 0;
@@ -20,7 +20,7 @@ function moneyTND(n?: number | null) {
 }
 
 export async function generateMetadata({ params }: Params): Promise<Metadata> {
-  const data = await fetchMotoFull(params.id).catch(() => null);
+  const data = await fetchMotoFullBySlugOrId(params.id).catch(() => null);
   const title = data ? `${data.brand} ${data.model} | moto.tn` : 'Fiche moto | moto.tn';
   return { title };
 }
@@ -28,10 +28,11 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
 export default async function MotoPage({ params }: Params) {
   let data: any = null;
   try {
-    data = await fetchMotoFull(params.id);
+    data = await fetchMotoFullBySlugOrId(params.id);
   } catch (error) {
     console.error('Erreur fn_get_moto_full:', error);
   }
+  console.debug('[moto] detail', !!data);
 
   if (!data) {
     return (
@@ -42,8 +43,10 @@ export default async function MotoPage({ params }: Params) {
     );
   }
 
-  const images = (data.images ?? []).sort((a: any, b: any) =>
-    (Number(b.is_primary) - Number(a.is_primary)) || ((a.sort_order ?? 0) - (b.sort_order ?? 0))
+  const images = (data?.images ?? []).sort(
+    (a: any, b: any) =>
+      (Number(b.is_primary) - Number(a.is_primary)) ||
+      ((a.sort_order ?? 0) - (b.sort_order ?? 0))
   );
   const groups = data.groups ?? [];
 

--- a/src/app/motos/loading.tsx
+++ b/src/app/motos/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div className="max-w-6xl mx-auto px-4 py-8">
+      <p className="text-sm text-muted-foreground">Chargement...</p>
+    </div>
+  );
+}

--- a/src/app/motos/page.tsx
+++ b/src/app/motos/page.tsx
@@ -1,8 +1,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
-import { fetchMotoCards } from '@/services/motos';
+import { fetchMotoCards, type MotoCard } from '@/services/motos';
 import { publicImageUrl } from '@/lib/storage';
-import type { MotoCard } from '@/types/supabase';
 
 export const revalidate = 0;
 export const dynamic = 'force-dynamic';
@@ -17,16 +16,23 @@ function moneyTND(n?: number | null) {
 
 export default async function MotosPage() {
   let motos: MotoCard[] = [];
+  let errored = false;
   try {
     motos = await fetchMotoCards();
   } catch (error) {
     console.error('Erreur lecture v_moto_cards:', error);
+    errored = true;
   }
+  console.debug('[moto] rows', motos.length);
 
   return (
     <div className="max-w-6xl mx-auto px-4 py-8">
       <h1 className="text-3xl font-bold mb-6">Motos neuves</h1>
+      {errored && <p className="mb-4 text-sm text-red-500">Erreur de chargement.</p>}
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        {motos.length === 0 && !errored && (
+          <div className="col-span-full text-center text-sm text-muted-foreground">Aucune moto trouvée</div>
+        )}
         {motos.map(m => (
           <Link key={m.id} href={`/motos/${m.id}`} className="rounded-xl border p-3 hover:shadow">
             <div className="relative w-full aspect-video bg-gray-100 rounded-lg overflow-hidden mb-2">

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,5 +1,6 @@
 export function publicImageUrl(path?: string | null) {
   if (!path) return null;
   const base = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (!base) return null;
   return `${base}/storage/v1/object/public/${path}`;
 }

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,7 +1,11 @@
-'use client';
 import { createClient } from '@supabase/supabase-js';
 
-export const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  // eslint-disable-next-line no-console
+  console.warn('[Supabase] Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY');
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/src/services/motos.ts
+++ b/src/services/motos.ts
@@ -1,5 +1,14 @@
 import { supabase } from '@/lib/supabaseClient';
-import type { MotoCard, MotoFull } from '@/types/supabase';
+
+export type MotoCard = {
+  id: string;
+  brand: string;
+  model: string;
+  year: number | null;
+  price: number | null;
+  image_path: string | null;
+  slug: string | null;
+};
 
 export async function fetchMotoCards(): Promise<MotoCard[]> {
   const { data, error } = await supabase
@@ -8,12 +17,47 @@ export async function fetchMotoCards(): Promise<MotoCard[]> {
     .order('year', { ascending: false })
     .limit(2000);
   if (error) throw error;
-  return (data as MotoCard[]) ?? [];
+  return data ?? [];
 }
 
-export async function fetchMotoFull(id: string): Promise<MotoFull | null> {
-  const { data, error } = await supabase
-    .rpc('fn_get_moto_full', { p_moto_id: id });
+export type MotoImage = {
+  path: string | null;
+  alt: string | null;
+  is_primary: boolean | null;
+  sort_order: number | null;
+};
+
+export type MotoFull = {
+  id: string;
+  brand: string;
+  model: string;
+  year: number | null;
+  price: number | null;
+  images?: MotoImage[];
+  groups?: { group: string; items: { key: string; value: string | null; unit?: string | null }[] }[];
+};
+
+async function fetchMotoFullById(id: string): Promise<MotoFull | null> {
+  const { data, error } = await supabase.rpc('fn_get_moto_full', { p_moto_id: id });
   if (error) throw error;
-  return data as MotoFull | null;
+  return (data as MotoFull) ?? null;
+}
+
+export async function resolveIdFromSlug(slug: string): Promise<string | null> {
+  const { data, error } = await supabase
+    .from('motos')
+    .select('id')
+    .eq('slug', slug)
+    .limit(1)
+    .maybeSingle();
+  if (error) throw error;
+  return data?.id ?? null;
+}
+
+export async function fetchMotoFullBySlugOrId(identifier: string): Promise<MotoFull | null> {
+  // Si l’identifiant ressemble à un UUID, tente direct.
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  const id = uuidRegex.test(identifier) ? identifier : (await resolveIdFromSlug(identifier));
+  if (!id) return null;
+  return fetchMotoFullById(id);
 }


### PR DESCRIPTION
## Summary
- add shared Supabase client and storage helper
- implement motos data service for cards and full details
- connect motos list and detail pages to new Supabase views
- add loading fallbacks

## Testing
- `npm run lint` *(fails: next: not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b368b41000832b825b60cd46798b23