### PR TITLE
feat: add detailed moto view

### DIFF
--- a/src/app/motos/[id]/page.tsx
+++ b/src/app/motos/[id]/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next';
-import Image from 'next/image';
-import { fetchMotoFullBySlugOrId, type MotoFull } from '@/services/motos';
+import { fetchMotoFullBySlugOrId } from '@/services/motos';
 import { publicImageUrl } from '@/lib/storage';
 
 export const revalidate = 0;
@@ -10,12 +9,12 @@ export const dynamicParams = true;
 
 type Params = { params: { id: string } };
 
-function formatPrice(n?: number | null) {
+function fmt(n?: number | null) {
   if (n == null) return '';
   try {
-    return new Intl.NumberFormat('fr-TN').format(n) + ' TND';
+    return new Intl.NumberFormat('fr-TN').format(n);
   } catch {
-    return `${n} TND`;
+    return String(n);
   }
 }
 
@@ -26,91 +25,78 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
 }
 
 export default async function MotoPage({ params }: Params) {
-  let data: MotoFull | null = null;
+  const identifier = params.id;
+  console.debug('[detail] id/slug:', identifier);
+  let data = null;
+  let errored = false;
   try {
-    data = await fetchMotoFullBySlugOrId(params.id);
+    data = await fetchMotoFullBySlugOrId(identifier);
   } catch (error) {
     console.error('Erreur fn_get_moto_full:', error);
+    errored = true;
   }
-  console.debug('[moto] detail', !!data);
+  console.debug('[detail] has data:', !!data);
 
   if (!data) {
     return (
       <div className="max-w-5xl mx-auto px-4 py-10">
-        <h1 className="text-2xl font-bold">Fiche indisponible</h1>
-        <p className="mt-2 text-muted-foreground">La moto demandée n’existe pas ou a été supprimée.</p>
+        <div className="text-sm text-muted-foreground">
+          {errored ? 'Erreur de chargement' : 'Fiche indisponible'}
+        </div>
       </div>
     );
   }
 
-  const moto = data as MotoFull;
-  const images = (moto.images ?? []).sort(
-    (a: any, b: any) =>
-      (Number(b.is_primary) - Number(a.is_primary)) ||
-      ((a.sort_order ?? 0) - (b.sort_order ?? 0))
-  );
-  const groups = moto.groups ?? [];
-
   return (
     <div className="max-w-5xl mx-auto px-4 py-8">
-      <div className="mb-6">
-        <h1 className="text-3xl font-bold">{moto.brand} {moto.model}</h1>
-        {moto.year && <p className="text-sm text-muted-foreground">{moto.year}</p>}
-        {moto.price != null && (
-          <p className="text-sm font-medium">{formatPrice(Number(moto.price))}</p>
-        )}
-      </div>
-
-      {publicImageUrl(images[0]?.path) && (
-        <div className="relative w-full max-w-3xl aspect-video bg-gray-100 rounded-xl overflow-hidden mb-6">
-          <Image
-            src={publicImageUrl(images[0].path)!}
-            alt={images[0].alt ?? `${moto.brand} ${moto.model}`}
-            fill
-            className="object-contain"
-          />
+      <header className="mb-4">
+        <h1 className="text-3xl font-bold">{data.brand} {data.model}</h1>
+        <div className="text-sm text-muted-foreground">
+          {data.year ?? ''} {data.price != null ? ` • ${fmt(data.price)} TND` : ''}
         </div>
-      )}
+      </header>
 
-      {images.length > 1 && (
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-8">
-          {images.map((img: any, idx: number) => (
-            <div key={idx} className="relative w-full aspect-square bg-gray-100 rounded-lg overflow-hidden">
-              {publicImageUrl(img.path) && (
-                <Image
-                  src={publicImageUrl(img.path)!}
-                  alt={img.alt ?? `${moto.brand} ${moto.model}`}
-                  fill
-                  className="object-cover"
-                />
-              )}
-            </div>
-          ))}
+      {data.images?.length ? (
+        <div className="flex gap-2 overflow-x-auto mb-6">
+          {data.images.map((img, i) => {
+            const src = publicImageUrl(img.path);
+            if (!src) return null;
+            return (
+              <img
+                key={i}
+                src={src}
+                alt={img.alt ?? `${data.brand} ${data.model}`}
+                className="h-48 w-auto object-cover rounded"
+              />
+            );
+          })}
         </div>
-      )}
+      ) : null}
 
-      {groups.length > 0 ? (
-        groups.map((g: any) => (
-          <div key={g.group} className="mb-6">
-            <h2 className="text-xl font-semibold mb-3">{g.group}</h2>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-              {(g.items ?? [])
-                .filter((it: any) => it.value)
-                .map((it: any, idx: number) => (
-                  <div key={idx} className="rounded-lg border p-3">
-                    <div className="text-sm font-medium">{it.key}</div>
-                    <div className="text-sm text-muted-foreground">
-                      {it.value}
-                      {it.unit ? ` ${it.unit}` : ''}
+      <section className="mt-6">
+        {data.groups?.length ? (
+          data.groups.map((g, gi) => (
+            <div key={gi} className="mb-6">
+              <h3 className="text-xl font-semibold mb-3">{g.group}</h3>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                {g.items
+                  ?.filter(it => it && it.value)
+                  .map((it, ii) => (
+                    <div key={ii} className="rounded-lg border p-3">
+                      <div className="text-sm font-medium">{it.key}</div>
+                      <div className="text-sm text-muted-foreground">
+                        {it.value}{it.unit ? ` ${it.unit}` : ''}
+                      </div>
                     </div>
-                  </div>
-                ))}
+                  ))}
+              </div>
             </div>
-          </div>
-        ))
-      ) : (
-        <div className="text-sm text-muted-foreground">Aucune spécification</div>
-      )}
+          ))
+        ) : (
+          <div className="text-sm text-muted-foreground">Aucune spécification</div>
+        )}
+      </section>
     </div>
   );
 }
+

--- a/src/app/motos/[id]/page.tsx
+++ b/src/app/motos/[id]/page.tsx
@@ -47,10 +47,12 @@ export default async function MotoPage({ params }: Params) {
     );
   }
 
+  const { brand, model } = data;
+
   return (
     <div className="max-w-5xl mx-auto px-4 py-8">
       <header className="mb-4">
-        <h1 className="text-3xl font-bold">{data.brand} {data.model}</h1>
+        <h1 className="text-3xl font-bold">{brand} {model}</h1>
         <div className="text-sm text-muted-foreground">
           {data.year ?? ''} {data.price != null ? ` • ${fmt(data.price)} TND` : ''}
         </div>
@@ -65,7 +67,7 @@ export default async function MotoPage({ params }: Params) {
               <img
                 key={i}
                 src={src}
-                alt={img.alt ?? `${data.brand} ${data.model}`}
+                alt={img.alt ?? `${brand} ${model}`}
                 className="h-48 w-auto object-cover rounded"
               />
             );

--- a/src/app/motos/[id]/page.tsx
+++ b/src/app/motos/[id]/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { fetchMotoFullBySlugOrId } from '@/services/motos';
+import { fetchMotoFullBySlugOrId, type MotoFull } from '@/services/motos';
 import { publicImageUrl } from '@/lib/storage';
 
 export const revalidate = 0;
@@ -27,7 +27,7 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
 export default async function MotoPage({ params }: Params) {
   const identifier = params.id;
   console.debug('[detail] id/slug:', identifier);
-  let data = null;
+  let data: MotoFull | null = null;
   let errored = false;
   try {
     data = await fetchMotoFullBySlugOrId(identifier);

--- a/src/services/motos.ts
+++ b/src/services/motos.ts
@@ -27,6 +27,17 @@ export type MotoImage = {
   sort_order: number | null;
 };
 
+export type MotoGroupItem = {
+  key: string;
+  value: string | null;
+  unit?: string | null;
+};
+
+export type MotoGroup = {
+  group: string;
+  items: MotoGroupItem[];
+};
+
 export type MotoFull = {
   id: string;
   brand: string;
@@ -34,30 +45,72 @@ export type MotoFull = {
   year: number | null;
   price: number | null;
   images?: MotoImage[];
-  groups?: { group: string; items: { key: string; value: string | null; unit?: string | null }[] }[];
+  groups?: MotoGroup[];
 };
 
-async function fetchMotoFullById(id: string): Promise<MotoFull | null> {
-  const { data, error } = await supabase.rpc('fn_get_moto_full', { p_moto_id: id });
-  if (error) throw error;
-  return (data as MotoFull) ?? null;
+function isUuid(x: string) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(x);
 }
 
-export async function resolveIdFromSlug(slug: string): Promise<string | null> {
+export async function resolveIdFromSlug(identifier: string): Promise<string | null> {
+  if (isUuid(identifier)) return identifier;
   const { data, error } = await supabase
     .from('motos')
     .select('id')
-    .eq('slug', slug)
+    .eq('slug', identifier)
     .limit(1)
     .maybeSingle();
   if (error) throw error;
   return data?.id ?? null;
 }
 
-export async function fetchMotoFullBySlugOrId(identifier: string): Promise<MotoFull | null> {
-  // Si l’identifiant ressemble à un UUID, tente direct.
-  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-  const id = uuidRegex.test(identifier) ? identifier : (await resolveIdFromSlug(identifier));
-  if (!id) return null;
-  return fetchMotoFullById(id);
+// Normalise le retour RPC (objet direct, string JSON, array[objet])
+function normalizeRpcResult(raw: any): MotoFull | null {
+  if (!raw) return null;
+  let obj = raw;
+  if (typeof raw === 'string') {
+    try { obj = JSON.parse(raw); } catch {}
+  }
+  if (Array.isArray(obj)) {
+    obj = obj[0] ?? null;
+  }
+  return obj as MotoFull | null;
 }
+
+// Tente p_moto_id (uuid), sinon p_moto_id_text (texte)
+async function callMotoFullRpc(id: string): Promise<MotoFull | null> {
+  // 1) p_moto_id
+  let { data, error } = await supabase.rpc('fn_get_moto_full', { p_moto_id: id });
+  if (!error && data) {
+    return normalizeRpcResult(data);
+  }
+  // 2) p_moto_id_text
+  ({ data, error } = await supabase.rpc('fn_get_moto_full', { p_moto_id_text: id }));
+  if (!error && data) {
+    return normalizeRpcResult(data);
+  }
+  // 3) certains environnements renvoient null sans error → dernier essai: p_moto_id en texte
+  ({ data, error } = await supabase.rpc('fn_get_moto_full', { p_moto_id: String(id) }));
+  if (!error && data) {
+    return normalizeRpcResult(data);
+  }
+  // remonter la dernière erreur si dispo
+  if (error) throw error;
+  return null;
+}
+
+export async function fetchMotoFullBySlugOrId(identifier: string): Promise<MotoFull | null> {
+  const id = await resolveIdFromSlug(identifier);
+  if (!id) return null;
+  const payload = await callMotoFullRpc(id);
+  if (!payload) return null;
+
+  // tri images côté client
+  const images = (payload.images ?? []).slice().sort(
+    (a, b) =>
+      (Number(b.is_primary) - Number(a.is_primary)) ||
+      ((a.sort_order ?? 0) - (b.sort_order ?? 0))
+  );
+  return { ...payload, images };
+}
+


### PR DESCRIPTION
## Summary
- enhance moto service to resolve slug or id and normalize RPC responses
- implement moto detail page rendering images and grouped specs

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next not found)
- `npm run typecheck` (fails: numerous TS2307 and other errors)


------
https://chatgpt.com/codex/tasks/task_e_68b36cec59f4832bb2643d95e7216a78