### PR TITLE
Handle full moto data from Supabase RPC

### DIFF
--- a/src/app/motos/[id]/page.tsx
+++ b/src/app/motos/[id]/page.tsx
@@ -9,14 +9,7 @@ export const dynamicParams = true;
 
 type Params = { params: { id: string } };
 
-function fmt(n?: number | null) {
-  if (n == null) return '';
-  try {
-    return new Intl.NumberFormat('fr-TN').format(n);
-  } catch {
-    return String(n);
-  }
-}
+const fmt = (n?: number | null) => (n == null ? '' : new Intl.NumberFormat('fr-TN').format(n));
 
 export async function generateMetadata({ params }: Params): Promise<Metadata> {
   const data = await fetchMotoFullBySlugOrId(params.id).catch(() => null);
@@ -26,23 +19,19 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
 
 export default async function MotoPage({ params }: Params) {
   const identifier = params.id;
-  console.debug('[detail] id/slug:', identifier);
+  console.debug('[detail] id:', identifier);
   let data: MotoFull | null = null;
-  let errored = false;
   try {
     data = await fetchMotoFullBySlugOrId(identifier);
   } catch (error) {
     console.error('Erreur fn_get_moto_full:', error);
-    errored = true;
   }
   console.debug('[detail] has data:', !!data);
 
   if (!data) {
     return (
       <div className="max-w-5xl mx-auto px-4 py-10">
-        <div className="text-sm text-muted-foreground">
-          {errored ? 'Erreur de chargement' : 'Fiche indisponible'}
-        </div>
+        <div className="text-sm text-muted-foreground">Fiche indisponible</div>
       </div>
     );
   }
@@ -54,11 +43,11 @@ export default async function MotoPage({ params }: Params) {
       <header className="mb-4">
         <h1 className="text-3xl font-bold">{brand} {model}</h1>
         <div className="text-sm text-muted-foreground">
-          {data.year ?? ''} {data.price != null ? ` • ${fmt(data.price)} TND` : ''}
+          {data.year ?? ''}{data.price != null ? ` • ${fmt(data.price)} TND` : ''}
         </div>
       </header>
 
-      {data.images?.length ? (
+      {!!data.images?.length && (
         <div className="flex gap-2 overflow-x-auto mb-6">
           {data.images.map((img, i) => {
             const src = publicImageUrl(img.path);
@@ -73,7 +62,7 @@ export default async function MotoPage({ params }: Params) {
             );
           })}
         </div>
-      ) : null}
+      )}
 
       <section className="mt-6">
         {data.groups?.length ? (
@@ -81,16 +70,14 @@ export default async function MotoPage({ params }: Params) {
             <div key={gi} className="mb-6">
               <h3 className="text-xl font-semibold mb-3">{g.group}</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                {g.items
-                  ?.filter(it => it && it.value)
-                  .map((it, ii) => (
-                    <div key={ii} className="rounded-lg border p-3">
-                      <div className="text-sm font-medium">{it.key}</div>
-                      <div className="text-sm text-muted-foreground">
-                        {it.value}{it.unit ? ` ${it.unit}` : ''}
-                      </div>
+                {g.items?.filter(it => it?.value).map((it, ii) => (
+                  <div key={ii} className="rounded-lg border p-3">
+                    <div className="text-sm font-medium">{it.key}</div>
+                    <div className="text-sm text-muted-foreground">
+                      {it.value}{it.unit ? ` ${it.unit}` : ''}
                     </div>
-                  ))}
+                  </div>
+                ))}
               </div>
             </div>
           ))

--- a/src/app/motos/page.tsx
+++ b/src/app/motos/page.tsx
@@ -7,14 +7,7 @@ export const revalidate = 0;
 export const dynamic = 'force-dynamic';
 export const fetchCache = 'force-no-store';
 
-function formatPrice(n?: number | null) {
-  if (n == null) return '';
-  try {
-    return new Intl.NumberFormat('fr-TN').format(n) + ' TND';
-  } catch {
-    return `${n} TND`;
-  }
-}
+const fmt = (n?: number | null) => n == null ? '' : new Intl.NumberFormat('fr-TN').format(n) + ' TND';
 
 export default async function MotosPage() {
   let motos: MotoCard[] = [];
@@ -35,21 +28,24 @@ export default async function MotosPage() {
         {motos.length === 0 && !errored && (
           <div className="col-span-full text-center text-sm text-muted-foreground">Aucune moto trouvée</div>
         )}
-        {motos.map(m => (
-          <Link key={m.id} href={`/motos/${m.slug ?? m.id}`} className="rounded-xl border p-3 hover:shadow">
-            <div className="relative w-full aspect-video bg-gray-100 rounded-lg overflow-hidden mb-2">
-              {publicImageUrl(m.image_path) ? (
-                <Image src={publicImageUrl(m.image_path)!} alt={`${m.brand} ${m.model}`} fill className="object-cover" />
-              ) : (
-                <div className="w-full h-full grid place-items-center text-xs text-gray-500">Pas d’image</div>
+        {motos.map(m => {
+          const title = [m.brand, m.model, m.year ?? ''].filter(Boolean).join(' ').trim();
+          return (
+            <Link key={m.id} href={`/motos/${m.slug ?? m.id}`} className="rounded-xl border p-3 hover:shadow">
+              <div className="relative w-full aspect-video bg-gray-100 rounded-lg overflow-hidden mb-2">
+                {publicImageUrl(m.image_path) ? (
+                  <Image src={publicImageUrl(m.image_path)!} alt={title} fill className="object-cover" />
+                ) : (
+                  <div className="w-full h-full grid place-items-center text-xs text-gray-500">Pas d’image</div>
+                )}
+              </div>
+              <div className="text-sm font-semibold">{title}</div>
+              {m.price != null && (
+                <div className="text-xs text-gray-600">{fmt(m.price)}</div>
               )}
-            </div>
-            <div className="text-sm font-semibold">{m.brand} {m.model} {m.year ?? ''}</div>
-            {m.price != null && (
-              <div className="text-xs text-gray-600">{formatPrice(m.price)}</div>
-            )}
-          </Link>
-        ))}
+            </Link>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/MotoCard.tsx
+++ b/src/components/MotoCard.tsx
@@ -1,20 +1,35 @@
-import Image from "next/image";
-import Link from "next/link";
-import type { MotoCard as Moto } from "@/lib/public/motos";
-import { publicImageUrl } from "@/lib/storage";
+import Image from 'next/image';
+import Link from 'next/link';
+import { publicImageUrl } from '@/lib/storage';
+
+type Moto = {
+  id: string;
+  brand: string | null;
+  model: string | null;
+  year: number | null;
+  price: number | null;
+  slug: string | null;
+  image_path?: string | null;
+  display_image?: string | null;
+};
 
 interface MotoCardProps {
   moto: Moto;
 }
 
 function formatPrice(price?: number | null) {
-  if (price == null) return "";
-  return new Intl.NumberFormat("fr-TN").format(price) + " TND";
+  if (price == null) return '';
+  return new Intl.NumberFormat('fr-TN').format(price) + ' TND';
 }
 
 export default function MotoCard({ moto }: MotoCardProps) {
-  const src = publicImageUrl(moto.display_image ?? undefined) || "/images/placeholder.jpg";
-  const title = [moto.brand, moto.model, moto.year ?? ""].filter(Boolean).join(" ").trim();
+  const src =
+    publicImageUrl(moto.image_path ?? moto.display_image ?? undefined) ||
+    '/images/placeholder.jpg';
+  const title = [moto.brand, moto.model, moto.year ?? '']
+    .filter(Boolean)
+    .join(' ')
+    .trim();
 
   return (
     <div className="rounded-xl border overflow-hidden hover:shadow">
@@ -22,7 +37,7 @@ export default function MotoCard({ moto }: MotoCardProps) {
         <div className="aspect-[16/9] bg-gray-100 relative">
           <Image
             src={src}
-            alt={title || ""}
+            alt={title || ''}
             fill
             className="object-cover"
           />


### PR DESCRIPTION
## Summary
- add robust moto service resolving slug/id and normalizing RPC responses
- show brand and price on moto list cards
- render complete moto details with images and specs
- support image_path in MotoCard component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm run typecheck` *(fails: Cannot find module 'next/server', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b372c20d34832b966096a14fe2f057