### PR TITLE
feat: display moto specs via Supabase

### DIFF
--- a/src/app/moto/[id]/page.tsx
+++ b/src/app/moto/[id]/page.tsx
@@ -1,0 +1,53 @@
+import Image from 'next/image';
+import { getMotoFull } from '@/lib/getMotoFull';
+
+export default async function MotoPage({ params }: { params: { id: string } }) {
+  const fiche = await getMotoFull(params.id);
+
+  if (!fiche?.moto) {
+    return <div className="p-6">Moto introuvable.</div>;
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto p-6 space-y-8">
+      <header className="flex items-center gap-4">
+        {fiche.moto.display_image ? (
+          <Image
+            src={fiche.moto.display_image}
+            alt={`${fiche.moto.brand} ${fiche.moto.model}`}
+            width={220}
+            height={140}
+          />
+        ) : null}
+        <div>
+          <h1 className="text-2xl font-semibold">
+            {fiche.moto.brand} {fiche.moto.model} {fiche.moto.year}
+          </h1>
+          {typeof fiche.moto.price === 'number' ? (
+            <p className="opacity-70">{fiche.moto.price} TND</p>
+          ) : null}
+        </div>
+      </header>
+
+      <section className="space-y-6">
+        {fiche.specs?.map((grp) => (
+          <div key={grp.group} className="rounded-2xl border p-4">
+            <h2 className="text-lg font-medium mb-3">{grp.group}</h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {grp.items?.map((it, idx) => {
+                const raw = it.value_text ?? it.value_number ?? (typeof it.value_boolean === 'boolean' ? (it.value_boolean ? 'Oui' : 'Non') : null) ?? (it.value_json ? JSON.stringify(it.value_json) : '');
+                const val = [raw, it.unit].filter(Boolean).join(' ');
+                return (
+                  <div key={it.key + idx} className="flex justify-between gap-4 border-b py-2">
+                    <span className="opacity-70">{it.label}</span>
+                    <span className="font-medium">{val}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/src/lib/getMotoFull.ts
+++ b/src/lib/getMotoFull.ts
@@ -1,0 +1,14 @@
+import { supabase } from './supabaseClient';
+
+export type MotoFull = {
+  moto: { id: string; brand: string; model: string; year: number; price?: number | null; display_image?: string | null } | null;
+  specs: { group: string; items: { key: string; label: string; unit: string | null; value_text?: string | null; value_number?: number | null; value_boolean?: boolean | null; value_json?: any }[] }[];
+};
+
+export async function getMotoFull(motoId: string): Promise<MotoFull> {
+  const { data, error } = await supabase
+    .rpc('fn_get_moto_full', { p_moto_id: motoId });
+
+  if (error) throw error;
+  return (data as MotoFull) ?? { moto: null, specs: [] };
+}

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,11 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-
-if (!supabaseUrl || !supabaseAnonKey) {
-  // eslint-disable-next-line no-console
-  console.warn('[Supabase] Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY');
-}
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+);

--- a/supabase/functions/fn_get_moto_full.sql
+++ b/supabase/functions/fn_get_moto_full.sql
@@ -1,0 +1,76 @@
+-- DROP FUNCTION IF EXISTS public.fn_get_moto_full(uuid);
+CREATE OR REPLACE FUNCTION public.fn_get_moto_full(p_moto_id uuid)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+AS $$
+WITH m AS (
+  SELECT id, brand, model, year, price, display_image
+  FROM public.motos
+  WHERE id = p_moto_id
+  LIMIT 1
+),
+groups AS (
+  SELECT
+    g.id,
+    g.name,
+    g.sort_order
+  FROM public.spec_groups g
+  WHERE EXISTS (
+    SELECT 1
+    FROM public.spec_items i
+    JOIN public.moto_spec_values mv ON mv.spec_item_id = i.id
+    WHERE i.group_id = g.id AND mv.moto_id = p_moto_id
+  )
+),
+items AS (
+  SELECT
+    i.id,
+    i.key,
+    i.label,
+    i.group_id,
+    i.unit AS default_unit,
+    i.sort_order,
+    mv.value_text,
+    mv.value_number,
+    mv.value_boolean,
+    mv.value_json,
+    COALESCE(mv.unit, i.unit) AS unit
+  FROM public.spec_items i
+  JOIN public.moto_spec_values mv ON mv.spec_item_id = i.id
+  WHERE mv.moto_id = p_moto_id
+)
+SELECT jsonb_build_object(
+  'moto', (SELECT to_jsonb(m.*) FROM m),
+  'specs',
+    (
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'group', g.name,
+          'items',
+            (
+              SELECT jsonb_agg(
+                jsonb_build_object(
+                  'key', it.key,
+                  'label', it.label,
+                  'unit', it.unit,
+                  'value_text', it.value_text,
+                  'value_number', it.value_number,
+                  'value_boolean', it.value_boolean,
+                  'value_json', it.value_json
+                )
+                ORDER BY it.sort_order NULLS LAST, it.label
+              )
+              FROM items it
+              WHERE it.group_id = g.id
+            )
+        )
+        ORDER BY g.sort_order NULLS LAST, g.name
+      )
+      FROM groups g
+    )
+);
+$$;
+
+COMMENT ON FUNCTION public.fn_get_moto_full IS
+'Retourne un JSONB: { moto: {...}, specs: [{group, items:[{key,label,unit,value_*}]}] } pour une moto donnée.';


### PR DESCRIPTION
## Summary
- add SQL function `fn_get_moto_full` and RPC retrieval
- set up Supabase client and server utility to fetch moto specs
- render moto details and grouped specs on `/moto/[id]`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm install --no-audit --progress=false` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@supabase%2fssr)*
- `npm run typecheck` *(fails: cannot find module 'next/image' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68b39a9333a8832bb60ba50c12b1346a