### PR TITLE
feat: show specs with values

### DIFF
--- a/src/app/moto/[id]/page.tsx
+++ b/src/app/moto/[id]/page.tsx
@@ -1,12 +1,25 @@
+'use client';
 import Image from 'next/image';
-import { getMotoFull } from '@/lib/getMotoFull';
+import { useEffect, useState } from 'react';
+import { getMotoFull, MotoFull } from '@/lib/getMotoFull';
 
-export default async function MotoPage({ params }: { params: { id: string } }) {
-  const fiche = await getMotoFull(params.id);
+export default function MotoPage({ params }: { params: { id: string } }) {
+  const [fiche, setFiche] = useState<MotoFull | null>(null);
+  const [err, setErr] = useState<string | null>(null);
 
-  if (!fiche?.moto) {
-    return <div className="p-6">Moto introuvable.</div>;
-  }
+  useEffect(() => {
+    (async () => {
+      try {
+        const d = await getMotoFull(params.id);
+        setFiche(d);
+      } catch (e: any) {
+        setErr(e?.message ?? 'Erreur de chargement');
+      }
+    })();
+  }, [params.id]);
+
+  if (err) return <div className="p-6 text-red-600">Erreur : {err}</div>;
+  if (!fiche?.moto) return <div className="p-6">Chargement…</div>;
 
   return (
     <div className="max-w-5xl mx-auto p-6 space-y-8">
@@ -29,22 +42,26 @@ export default async function MotoPage({ params }: { params: { id: string } }) {
         </div>
       </header>
 
+      {/* Groupes + sous-caractéristiques + valeurs */}
       <section className="space-y-6">
         {fiche.specs?.map((grp) => (
           <div key={grp.group} className="rounded-2xl border p-4">
             <h2 className="text-lg font-medium mb-3">{grp.group}</h2>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-              {grp.items?.map((it, idx) => {
-                const raw = it.value_text ?? it.value_number ?? (typeof it.value_boolean === 'boolean' ? (it.value_boolean ? 'Oui' : 'Non') : null) ?? (it.value_json ? JSON.stringify(it.value_json) : '');
-                const val = [raw, it.unit].filter(Boolean).join(' ');
-                return (
-                  <div key={it.key + idx} className="flex justify-between gap-4 border-b py-2">
-                    <span className="opacity-70">{it.label}</span>
-                    <span className="font-medium">{val}</span>
-                  </div>
-                );
-              })}
-            </div>
+            {(!grp.items || grp.items.length === 0) ? (
+              <div className="opacity-60">Aucune donnée</div>
+            ) : (
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                {grp.items.map((it, idx) => {
+                  const pretty = it.value_pretty ?? '';
+                  return (
+                    <div key={it.key + idx} className="flex justify-between gap-4 border-b py-2">
+                      <span className="opacity-70">{it.label}</span>
+                      <span className="font-medium">{pretty}</span>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
           </div>
         ))}
       </section>

--- a/src/lib/getMotoFull.ts
+++ b/src/lib/getMotoFull.ts
@@ -2,13 +2,11 @@ import { supabase } from './supabaseClient';
 
 export type MotoFull = {
   moto: { id: string; brand: string; model: string; year: number; price?: number | null; display_image?: string | null } | null;
-  specs: { group: string; items: { key: string; label: string; unit: string | null; value_text?: string | null; value_number?: number | null; value_boolean?: boolean | null; value_json?: any }[] }[];
+  specs: { group: string; items: { key: string; label: string; unit: string | null; value_text?: string | null; value_number?: number | null; value_boolean?: boolean | null; value_json?: any; value_pretty?: string | null }[] }[];
 };
 
 export async function getMotoFull(motoId: string): Promise<MotoFull> {
-  const { data, error } = await supabase
-    .rpc('fn_get_moto_full', { p_moto_id: motoId });
-
+  const { data, error } = await supabase.rpc('fn_get_moto_full', { p_moto_id: motoId });
   if (error) throw error;
   return (data as MotoFull) ?? { moto: null, specs: [] };
 }

--- a/supabase/migrations/20250831_fn_get_moto_full.sql
+++ b/supabase/migrations/20250831_fn_get_moto_full.sql
@@ -1,0 +1,86 @@
+-- DROP FUNCTION IF EXISTS public.fn_get_moto_full(uuid);
+CREATE OR REPLACE FUNCTION public.fn_get_moto_full(p_moto_id uuid)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+AS $$
+WITH m AS (
+  SELECT id, brand, model, year, price, display_image
+  FROM public.motos
+  WHERE id = p_moto_id
+  LIMIT 1
+),
+grp AS (
+  SELECT DISTINCT g.id, g.name, g.sort_order
+  FROM public.spec_groups g
+  JOIN public.spec_items i ON i.group_id = g.id
+  JOIN public.moto_spec_values mv ON mv.spec_item_id = i.id
+  WHERE mv.moto_id = p_moto_id
+),
+it AS (
+  SELECT
+    i.id,
+    i.key,
+    i.label,
+    i.group_id,
+    i.sort_order,
+    COALESCE(mv.unit, i.unit) AS unit,
+    mv.value_text,
+    mv.value_number,
+    mv.value_boolean,
+    mv.value_json,
+    /* valeur lisible unique */
+    TRIM(BOTH ' ' FROM
+      COALESCE(
+        NULLIF(mv.value_text, ''),
+        CASE WHEN mv.value_number IS NOT NULL THEN (mv.value_number::text) END,
+        CASE WHEN mv.value_boolean IS NOT NULL THEN (CASE WHEN mv.value_boolean THEN 'Oui' ELSE 'Non' END) END,
+        CASE WHEN mv.value_json IS NOT NULL THEN (mv.value_json::text) END,
+        ''
+      )
+    ) AS value_raw
+  FROM public.spec_items i
+  JOIN public.moto_spec_values mv ON mv.spec_item_id = i.id
+  WHERE mv.moto_id = p_moto_id
+)
+SELECT jsonb_build_object(
+  'moto', (SELECT to_jsonb(m.*) FROM m),
+  'specs',
+  (
+    SELECT COALESCE(
+      jsonb_agg(
+        jsonb_build_object(
+          'group', g.name,
+          'items',
+          (
+            SELECT COALESCE(
+              jsonb_agg(
+                jsonb_build_object(
+                  'key', i.key,
+                  'label', i.label,
+                  'unit', i.unit,
+                  'value_text', i.value_text,
+                  'value_number', i.value_number,
+                  'value_boolean', i.value_boolean,
+                  'value_json', i.value_json,
+                  'value_pretty', TRIM(BOTH ' ' FROM (COALESCE(i.value_raw,'') || CASE WHEN i.unit IS NULL OR i.unit = '' THEN '' ELSE ' ' || i.unit END))
+                )
+                ORDER BY i.sort_order NULLS LAST, i.label
+              ),
+              '[]'::jsonb
+            )
+            FROM it i
+            WHERE i.group_id = g.id
+          )
+        )
+        ORDER BY g.sort_order NULLS LAST, g.name
+      ),
+      '[]'::jsonb
+    )
+    FROM grp g
+  )
+);
+$$;
+
+COMMENT ON FUNCTION public.fn_get_moto_full IS
+'Retourne {moto, specs:[{group, items:[{key,label,unit,value_*,value_pretty}]}]} incluant sous-caractéristiques et valeurs pour une moto.';


### PR DESCRIPTION
## Summary
- add RPC `fn_get_moto_full` to load moto groups, items and values
- fetch moto specs from Supabase and render with `value_pretty`
- display technical data on `/moto/[id]`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@supabase%2fssr)*
- `npm run typecheck` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b39bf39d0c832b82e58d4d929d8f62