### PR TITLE
feat: add moto comparator APIs and page

### DIFF
--- a/src/app/api/moto-comparator/route.ts
+++ b/src/app/api/moto-comparator/route.ts
@@ -1,16 +1,13 @@
-// RPC-based comparator endpoint for motos
 import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 
 export async function POST(req: NextRequest) {
   try {
-    const { ids = [] } = (await req.json().catch(() => ({ ids: [] }))) as {
-      ids?: string[];
-    };
+    const { ids } = (await req.json()) as { ids: string[] };
 
-    if (!Array.isArray(ids)) {
-      return NextResponse.json({ error: 'ids must be an array' }, { status: 400 });
+    if (!Array.isArray(ids) || ids.length === 0) {
+      return NextResponse.json({ error: 'ids required' }, { status: 400 });
     }
     if (ids.length > 4) {
       return NextResponse.json({ error: 'Maximum 4 motos' }, { status: 400 });
@@ -35,3 +32,4 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: e?.message ?? 'Unexpected error' }, { status: 500 });
   }
 }
+

--- a/src/app/api/motos/brands/route.ts
+++ b/src/app/api/motos/brands/route.ts
@@ -1,4 +1,3 @@
-// Returns all unique moto brands
 import { NextResponse } from 'next/server';
 import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
@@ -30,3 +29,4 @@ export async function GET() {
     return NextResponse.json({ error: e?.message ?? 'Unexpected error' }, { status: 500 });
   }
 }
+

--- a/src/app/api/motos/by-brand/route.ts
+++ b/src/app/api/motos/by-brand/route.ts
@@ -1,4 +1,3 @@
-// List motos for a given brand
 import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
@@ -31,3 +30,4 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: e?.message ?? 'Unexpected error' }, { status: 500 });
   }
 }
+

--- a/src/app/comparateur/page.tsx
+++ b/src/app/comparateur/page.tsx
@@ -1,14 +1,264 @@
-import type { Metadata } from 'next';
-import CompareClient from './CompareClient';
-import { getPublishedMotos } from '@/lib/public/motos';
+'use client';
 
-export const metadata: Metadata = {
-  title: 'Comparateur',
-  description: 'Comparez plusieurs modèles de motos',
+import { useEffect, useMemo, useState } from 'react';
+import Image from 'next/image';
+
+type MotoRow = {
+  id: string;
+  brand: string | null;
+  model: string | null;
+  year: number | null;
+  price: number | null;
+  image: string | null;
 };
 
-export default async function ComparateurPage() {
-  const motos = await getPublishedMotos();
-  return <CompareClient motos={motos} />;
+type ComparatorPayload = {
+  motos: MotoRow[];
+  specs: {
+    group: string;
+    items: {
+      item_id: string;
+      key: string;
+      label: string;
+      unit: string | null;
+      values: Record<string, string | null>;
+    }[];
+  }[];
+};
+
+export default function ComparateurPage() {
+  const [brands, setBrands] = useState<string[]>([]);
+  const [brand, setBrand] = useState<string>('');
+  const [motoOptions, setMotoOptions] = useState<MotoRow[]>([]);
+  const [selected, setSelected] = useState<MotoRow[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [table, setTable] = useState<ComparatorPayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Charger les marques distinctes
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch('/api/motos/brands', { cache: 'no-store' });
+        const json = await res.json();
+        if (res.ok && Array.isArray(json?.brands)) setBrands(json.brands);
+      } catch {
+        // ignore
+      }
+    })();
+  }, []);
+
+  // Charger les modèles d’une marque
+  useEffect(() => {
+    (async () => {
+      setMotoOptions([]);
+      if (!brand) return;
+      try {
+        const res = await fetch('/api/motos/by-brand', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ brand }),
+        });
+        const json = await res.json();
+        if (!res.ok) return;
+
+        const rows = (json?.motos ?? []) as any[];
+        const opts: MotoRow[] = rows.map((m) => ({
+          id: m.id,
+          brand: m.brand ?? m.marque ?? m.make ?? null,
+          model: m.model ?? m.modele ?? m.model_name ?? null,
+          year: m.year ?? null,
+          price: m.price_tnd ?? m.price ?? null,
+          image: m.display_image ?? m.image_url ?? m.cover_image ?? m.image ?? null,
+        }));
+        setMotoOptions(opts);
+      } catch {
+        // ignore
+      }
+    })();
+  }, [brand]);
+
+  const canAddMore = selected.length < 4;
+
+  const addMoto = (id: string) => {
+    if (!canAddMore) return;
+    const m = motoOptions.find((o) => o.id === id);
+    if (!m) return;
+    if (selected.some((s) => s.id === id)) return;
+    setSelected((prev) => [...prev, m]);
+    setTable(null);
+  };
+
+  const removeMoto = (id: string) => {
+    setSelected((prev) => prev.filter((m) => m.id !== id));
+    setTable(null);
+  };
+
+  const compareNow = async () => {
+    setError(null);
+    setTable(null);
+    if (selected.length < 2) {
+      setError('Choisis au moins 2 motos à comparer.');
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await fetch('/api/moto-comparator', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ ids: selected.map((s) => s.id) }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json?.ok) throw new Error(json?.error ?? 'Erreur API');
+      setTable(json.payload as ComparatorPayload);
+    } catch (e: any) {
+      setError(e?.message ?? 'Erreur inattendue');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const columns = useMemo(() => table?.motos ?? selected, [table, selected]);
+
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-6 space-y-6">
+      <h1 className="text-2xl font-bold">Comparateur de motos</h1>
+
+      {/* Sélecteurs */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3 items-end">
+        <div className="flex flex-col gap-1">
+          <label className="text-sm font-medium">Marque</label>
+          <select
+            className="border rounded-xl px-3 py-2"
+            value={brand}
+            onChange={(e) => setBrand(e.target.value)}
+          >
+            <option value="">-- Choisir une marque --</option>
+            {brands.map((b) => (
+              <option key={b} value={b}>{b}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-sm font-medium">Modèle</label>
+          <select
+            className="border rounded-xl px-3 py-2"
+            disabled={!brand || motoOptions.length === 0 || !canAddMore}
+            onChange={(e) => {
+              const id = e.target.value;
+              if (id) addMoto(id);
+              e.currentTarget.selectedIndex = 0;
+            }}
+          >
+            <option value="">{brand ? '— Ajouter un modèle —' : 'Sélectionne une marque'}</option>
+            {motoOptions.map((m) => (
+              <option key={m.id} value={m.id}>
+                {`${m.model ?? 'Modèle'}${m.year ? ` (${m.year})` : ''}`}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex gap-2">
+          <button
+            onClick={compareNow}
+            disabled={loading || selected.length < 2}
+            className="rounded-xl px-4 py-2 bg-black text-white disabled:opacity-50"
+          >
+            {loading ? 'Chargement…' : 'Comparer'}
+          </button>
+          <button
+            onClick={() => { setSelected([]); setTable(null); }}
+            className="rounded-xl px-4 py-2 border"
+          >
+            Réinitialiser
+          </button>
+        </div>
+      </div>
+
+      {/* Sélection courante */}
+      <div className="flex flex-wrap gap-3">
+        {selected.map((m) => (
+          <div key={m.id} className="flex items-center gap-3 border rounded-2xl p-3 shadow-sm">
+            <div className="relative h-14 w-20 overflow-hidden rounded-lg bg-gray-50">
+              {m.image ? (
+                <Image src={m.image} alt={`${m.brand} ${m.model}`} fill className="object-cover" />
+              ) : (
+                <div className="h-full w-full grid place-items-center text-xs text-gray-400">No image</div>
+              )}
+            </div>
+            <div className="text-sm">
+              <div className="font-medium">{m.brand} {m.model}</div>
+              <div className="text-gray-500">{m.year ?? ''} {m.price ? `• ${m.price} TND` : ''}</div>
+            </div>
+            <button
+              onClick={() => removeMoto(m.id)}
+              className="ml-2 text-sm px-2 py-1 rounded-lg border hover:bg-gray-50"
+              title="Retirer"
+            >
+              ❌
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {/* Tableau comparatif */}
+      {error && <div className="text-red-600 text-sm">{error}</div>}
+
+      {table && (
+        <div className="overflow-x-auto border rounded-2xl">
+          <table className="min-w-[800px] w-full text-sm">
+            <thead className="sticky top-0 bg-white z-10">
+              <tr>
+                <th className="w-64 text-left p-3">Caractéristiques</th>
+                {columns.map((m) => (
+                  <th key={m.id} className="p-3 text-left">
+                    <div className="flex items-center gap-2">
+                      <div className="relative h-10 w-14 overflow-hidden rounded-md bg-gray-50">
+                        {m.image ? (
+                          <Image src={m.image} alt={`${m.brand} ${m.model}`} fill className="object-cover" />
+                        ) : null}
+                      </div>
+                      <div>
+                        <div className="font-medium">{m.brand} {m.model}</div>
+                        <div className="text-gray-500">{m.year ?? ''}</div>
+                      </div>
+                    </div>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {table.specs.map((g, gi) => (
+                <GroupBlock key={gi} group={g} motos={columns} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function GroupBlock({ group, motos }: { group: ComparatorPayload['specs'][number]; motos: MotoRow[] }) {
+  return (
+    <>
+      <tr className="bg-blue-50/60">
+        <td className="p-3 font-semibold" colSpan={1 + motos.length}>{group.group}</td>
+      </tr>
+      {group.items.map((it) => (
+        <tr key={it.item_id} className="border-t">
+          <td className="p-3">
+            <div className="font-medium">{it.label}</div>
+            {it.unit ? <div className="text-xs text-gray-500">{it.unit}</div> : null}
+          </td>
+          {motos.map((m) => (
+            <td key={m.id} className="p-3 align-top">{it.values?.[m.id] ?? '—'}</td>
+          ))}
+        </tr>
+      ))}
+    </>
+  );
 }
 


### PR DESCRIPTION
## Summary
- add brand lookup endpoint
- add model lookup endpoint
- enhance moto comparator endpoint and comparateur page

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'next/server' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ba59b3c0832b9acd9447179b6840