### PR TITLE
feat: add moto comparator API endpoints

### DIFF
--- a/src/app/api/motos/brands/route.ts
+++ b/src/app/api/motos/brands/route.ts
@@ -11,18 +11,11 @@ export async function GET() {
       { cookies: { getAll: () => cookieStore.getAll(), setAll: () => {} } }
     );
 
-    const { data, error } = await s
-      .from('motos')
-      .select('brand, marque, make');
+    // Use RPC to avoid RLS/column name issues
+    const { data, error } = await s.rpc('fn_public_brands');
     if (error) throw error;
 
-    const set = new Set<string>();
-    (data ?? []).forEach((r: any) => {
-      const b = r?.brand ?? r?.marque ?? r?.make;
-      if (b) set.add(String(b));
-    });
-
-    const brands = Array.from(set).sort((a, b) => a.localeCompare(b));
+    const brands: string[] = Array.isArray(data) ? data.filter(Boolean) : [];
     return NextResponse.json({ brands });
   } catch (e: any) {
     console.error(e);

--- a/src/app/api/motos/by-brand/route.ts
+++ b/src/app/api/motos/by-brand/route.ts
@@ -16,14 +16,10 @@ export async function POST(req: NextRequest) {
       { cookies: { getAll: () => cookieStore.getAll(), setAll: () => {} } }
     );
 
-    const { data, error } = await s
-      .from('motos')
-      .select('id, brand, marque, make, model, modele, model_name, year, price, price_tnd, display_image, image_url, cover_image, image')
-      .or(`brand.eq.${brand},marque.eq.${brand},make.eq.${brand}`)
-      .order('model', { ascending: true })
-      .order('year', { ascending: false });
-
+    // RPC returns normalized columns
+    const { data, error } = await s.rpc('fn_motos_by_brand', { p_brand: brand });
     if (error) throw error;
+
     return NextResponse.json({ motos: data ?? [] });
   } catch (e: any) {
     console.error(e);

--- a/src/app/comparateur/page.tsx
+++ b/src/app/comparateur/page.tsx
@@ -35,24 +35,26 @@ export default function ComparateurPage() {
   const [table, setTable] = useState<ComparatorPayload | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  // Charger les marques distinctes
+  // Load brands
   useEffect(() => {
     (async () => {
       try {
         const res = await fetch('/api/motos/brands', { cache: 'no-store' });
         const json = await res.json();
         if (res.ok && Array.isArray(json?.brands)) setBrands(json.brands);
+        else setBrands([]);
       } catch {
-        // ignore
+        setBrands([]);
       }
     })();
   }, []);
 
-  // Charger les modèles d’une marque
+  // Load models for selected brand
   useEffect(() => {
     (async () => {
       setMotoOptions([]);
       if (!brand) return;
+
       try {
         const res = await fetch('/api/motos/by-brand', {
           method: 'POST',
@@ -65,11 +67,11 @@ export default function ComparateurPage() {
         const rows = (json?.motos ?? []) as any[];
         const opts: MotoRow[] = rows.map((m) => ({
           id: m.id,
-          brand: m.brand ?? m.marque ?? m.make ?? null,
-          model: m.model ?? m.modele ?? m.model_name ?? null,
+          brand: m.brand ?? null,
+          model: m.model ?? null,
           year: m.year ?? null,
-          price: m.price_tnd ?? m.price ?? null,
-          image: m.display_image ?? m.image_url ?? m.cover_image ?? m.image ?? null,
+          price: m.price ?? null,
+          image: m.image ?? null,
         }));
         setMotoOptions(opts);
       } catch {
@@ -124,7 +126,7 @@ export default function ComparateurPage() {
     <div className="mx-auto max-w-7xl px-4 py-6 space-y-6">
       <h1 className="text-2xl font-bold">Comparateur de motos</h1>
 
-      {/* Sélecteurs */}
+      {/* Selectors */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-3 items-end">
         <div className="flex flex-col gap-1">
           <label className="text-sm font-medium">Marque</label>
@@ -162,6 +164,7 @@ export default function ComparateurPage() {
 
         <div className="flex gap-2">
           <button
+            type="button"
             onClick={compareNow}
             disabled={loading || selected.length < 2}
             className="rounded-xl px-4 py-2 bg-black text-white disabled:opacity-50"
@@ -169,6 +172,7 @@ export default function ComparateurPage() {
             {loading ? 'Chargement…' : 'Comparer'}
           </button>
           <button
+            type="button"
             onClick={() => { setSelected([]); setTable(null); }}
             className="rounded-xl px-4 py-2 border"
           >
@@ -177,7 +181,7 @@ export default function ComparateurPage() {
         </div>
       </div>
 
-      {/* Sélection courante */}
+      {/* Selected chips */}
       <div className="flex flex-wrap gap-3">
         {selected.map((m) => (
           <div key={m.id} className="flex items-center gap-3 border rounded-2xl p-3 shadow-sm">
@@ -193,6 +197,7 @@ export default function ComparateurPage() {
               <div className="text-gray-500">{m.year ?? ''} {m.price ? `• ${m.price} TND` : ''}</div>
             </div>
             <button
+              type="button"
               onClick={() => removeMoto(m.id)}
               className="ml-2 text-sm px-2 py-1 rounded-lg border hover:bg-gray-50"
               title="Retirer"
@@ -203,9 +208,8 @@ export default function ComparateurPage() {
         ))}
       </div>
 
-      {/* Tableau comparatif */}
+      {/* Table */}
       {error && <div className="text-red-600 text-sm">{error}</div>}
-
       {table && (
         <div className="overflow-x-auto border rounded-2xl">
           <table className="min-w-[800px] w-full text-sm">


### PR DESCRIPTION
## Summary
- add RPC-based brands lookup under `/api/motos/brands`
- add RPC-based model lookup under `/api/motos/by-brand`
- update comparator page to load brands/models via API and compare up to 4 motos

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm run typecheck` *(fails: cannot find modules; npm install 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b3be79c1c0832b917f46c2c2e385f1