### PR TITLE
feat: add brand-model comparator filters

### DIFF
--- a/src/components/CompareFilters.tsx
+++ b/src/components/CompareFilters.tsx
@@ -1,0 +1,147 @@
+"use client";
+import React from "react";
+import { supabase } from "@/lib/supabaseClient";
+
+type Option = { value: string; label: string };
+
+export default function CompareFilters(props: {
+  onBrandChange?: (brandId: string | null) => void;
+  onModelChange?: (model: string | null) => void;
+  defaultBrandId?: string | null;
+  defaultModel?: string | null;
+}) {
+  const [brands, setBrands] = React.useState<Option[]>([]);
+  const [models, setModels] = React.useState<Option[]>([]);
+  const [brandId, setBrandId] = React.useState<string | null>(
+    props.defaultBrandId ?? null
+  );
+  const [model, setModel] = React.useState<string | null>(
+    props.defaultModel ?? null
+  );
+  const [loadingBrands, setLoadingBrands] = React.useState(false);
+  const [loadingModels, setLoadingModels] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    const loadBrands = async () => {
+      try {
+        setLoadingBrands(true);
+        setError(null);
+        const { data, error } = await supabase
+          .from("brands")
+          .select("id,name")
+          .order("name", { ascending: true });
+        if (error) throw error;
+        setBrands(
+          (data ?? []).map((b: any) => ({ value: b.id, label: b.name }))
+        );
+      } catch (e: any) {
+        console.error(e);
+        setError("Impossible de charger les marques.");
+      } finally {
+        setLoadingBrands(false);
+      }
+    };
+    loadBrands();
+  }, []);
+
+  React.useEffect(() => {
+    const loadModels = async () => {
+      if (!brandId) {
+        setModels([]);
+        setModel(null);
+        return;
+      }
+      try {
+        setLoadingModels(true);
+        setError(null);
+        let { data, error } = await supabase
+          .from("models")
+          .select("id,name")
+          .eq("brand_id", brandId)
+          .order("name", { ascending: true });
+        if (error?.code === "42P01" || error?.message?.includes("relation \"models\"")) {
+          const res = await supabase
+            .from("motos")
+            .select("model", { distinct: true })
+            .eq("brand_id", brandId)
+            .order("model", { ascending: true });
+          if (res.error) throw res.error;
+          const rows = (res.data ?? [])
+            .map((r: any) => r.model)
+            .filter((x: any) => !!x);
+          const uniq = Array.from(new Set(rows));
+          setModels(uniq.map((m: string) => ({ value: m, label: m })));
+        } else {
+          if (error) throw error;
+          setModels(
+            (data ?? []).map((m: any) => ({ value: m.id, label: m.name }))
+          );
+        }
+        setModel(null);
+      } catch (e: any) {
+        console.error(e);
+        setError("Impossible de charger les modèles.");
+        setModels([]);
+      } finally {
+        setLoadingModels(false);
+      }
+    };
+    loadModels();
+  }, [brandId]);
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <div>
+        <label className="block text-sm mb-2">Marque</label>
+        <select
+          className="w-full border rounded p-2"
+          value={brandId ?? ""}
+          onChange={(e) => {
+            const v = e.target.value || null;
+            setBrandId(v);
+            props.onBrandChange?.(v);
+          }}
+        >
+          <option value="">
+            {loadingBrands ? "Chargement…" : "Choisir une marque"}
+          </option>
+          {brands.map((b) => (
+            <option key={b.value} value={b.value}>
+              {b.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label className="block text-sm mb-2">Modèle</label>
+        <select
+          className="w-full border rounded p-2"
+          value={model ?? ""}
+          disabled={!brandId}
+          onChange={(e) => {
+            const v = e.target.value || null;
+            setModel(v);
+            props.onModelChange?.(v);
+          }}
+        >
+          <option value="">
+            {!brandId
+              ? "Choisir d’abord une marque"
+              : loadingModels
+              ? "Chargement…"
+              : "Choisir un modèle"}
+          </option>
+          {models.map((m) => (
+            <option key={m.value} value={m.value}>
+              {m.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {error && <p className="text-red-600 text-sm">{error}</p>}
+    </div>
+  );
+}

--- a/src/components/CompareFilters.tsx
+++ b/src/components/CompareFilters.tsx
@@ -63,7 +63,7 @@ export default function CompareFilters(props: {
         if (error?.code === "42P01" || error?.message?.includes("relation \"models\"")) {
           const res = await supabase
             .from("motos")
-            .select("model", { distinct: true })
+            .select("model")
             .eq("brand_id", brandId)
             .order("model", { ascending: true });
           if (res.error) throw res.error;


### PR DESCRIPTION
## Summary
- add CompareFilters component loading brands and models from Supabase
- integrate CompareFilters into comparateur page with Supabase moto lookup

## Testing
- `npm run lint` *(fails: next: not found)*
- `npm run typecheck` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c53e1ea4832b829b5717b9f7480b