### PR TITLE
Fix model selection in comparator by using model names

### DIFF
--- a/src/components/CompareFilters.tsx
+++ b/src/components/CompareFilters.tsx
@@ -75,7 +75,7 @@ export default function CompareFilters(props: {
         } else {
           if (error) throw error;
           setModels(
-            (data ?? []).map((m: any) => ({ value: m.id, label: m.name }))
+            (data ?? []).map((m: any) => ({ value: m.name, label: m.name }))
           );
         }
         setModel(null);

--- a/src/components/CompareFilters.tsx
+++ b/src/components/CompareFilters.tsx
@@ -57,23 +57,22 @@ export default function CompareFilters(props: {
         setError(null);
         let { data, error } = await supabase
           .from("models")
-          .select("id,name")
+          .select("name")
           .eq("brand_id", brandId)
           .order("name", { ascending: true });
-        if (error?.code === "42P01" || error?.message?.includes("relation \"models\"")) {
-          const res = await supabase
+
+        if (error || !(data?.length)) {
+          const { data: rows, error: err } = await supabase
             .from("motos")
             .select("model")
             .eq("brand_id", brandId)
             .order("model", { ascending: true });
-          if (res.error) throw res.error;
-          const rows = (res.data ?? [])
-            .map((r: any) => r.model)
-            .filter((x: any) => !!x);
-          const uniq = Array.from(new Set(rows));
+          if (err) throw err;
+          const uniq = Array.from(
+            new Set((rows ?? []).map((r: any) => r.model).filter(Boolean))
+          );
           setModels(uniq.map((m: string) => ({ value: m, label: m })));
         } else {
-          if (error) throw error;
           setModels(
             (data ?? []).map((m: any) => ({ value: m.name, label: m.name }))
           );


### PR DESCRIPTION
## Summary
- use model names rather than IDs when listing models for a brand so selections work

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm run typecheck` *(fails: missing module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c91f19b4832bb349ae95e53aed02