### PR TITLE
feat: display spec list in comparator

### DIFF
--- a/src/app/comparateur/page.tsx
+++ b/src/app/comparateur/page.tsx
@@ -1,174 +1,109 @@
 'use client';
 
-// Comparateur page using `motos` table instead of non-existing `public.models`
 import { useEffect, useMemo, useState } from 'react';
 import { createClient } from '@supabase/supabase-js';
 
-type Brand = { id: string; name: string };
-type Moto = {
+interface SpecGroup {
   id: string;
-  brand_id: string;
-  model_name: string;
-  year: number | null;
-  price_tnd: string | number | null;
-};
+  name: string;
+  sort_order: number | null;
+}
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL as string,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string
-);
+interface SpecItem {
+  id: string;
+  group_id: string;
+  key: string | null;
+  label: string;
+  unit: string | null;
+  sort_order: number | null;
+}
 
 export default function ComparatorPage() {
-  const [brands, setBrands] = useState<Brand[]>([]);
-  const [models, setModels] = useState<string[]>([]); // valeurs de model_name
-  const [selectedBrandId, setSelectedBrandId] = useState<string>('');
-  const [selectedModelName, setSelectedModelName] = useState<string>('');
-  const [error, setError] = useState<string>('');
-  const [items, setItems] = useState<Moto[]>([]);
+  const [groups, setGroups] = useState<SpecGroup[]>([]);
+  const [items, setItems] = useState<SpecItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  // Charger les marques
   useEffect(() => {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+    if (!url || !anon) {
+      setError('Variables NEXT_PUBLIC_SUPABASE_URL ou NEXT_PUBLIC_SUPABASE_ANON_KEY manquantes.');
+      setLoading(false);
+      return;
+    }
+
+    const supabase = createClient(url, anon);
+
     (async () => {
-      setError('');
-      const { data, error } = await supabase
-        .from('brands')
-        .select('id,name')
-        .order('name', { ascending: true });
-      if (error) return setError(error.message);
-      setBrands(data ?? []);
+      try {
+        const [groupsRes, itemsRes] = await Promise.all([
+          supabase
+            .from('spec_groups')
+            .select('id,name,sort_order')
+            .order('sort_order', { ascending: true, nullsFirst: false })
+            .order('name', { ascending: true }),
+          supabase
+            .from('spec_items')
+            .select('id,group_id,key,label,unit,sort_order')
+            .order('group_id', { ascending: true })
+            .order('sort_order', { ascending: true, nullsFirst: false })
+            .order('label', { ascending: true }),
+        ]);
+
+        if (groupsRes.error) throw groupsRes.error;
+        if (itemsRes.error) throw itemsRes.error;
+
+        setGroups(groupsRes.data ?? []);
+        setItems(itemsRes.data ?? []);
+      } catch (e: any) {
+        setError(e.message ?? 'Erreur inattendue');
+      } finally {
+        setLoading(false);
+      }
     })();
   }, []);
 
-  // Charger les modèles (depuis `motos`, distinct par brand_id)
-  useEffect(() => {
-    if (!selectedBrandId) {
-      setModels([]);
-      setSelectedModelName('');
-      return;
+  const itemsByGroup = useMemo(() => {
+    const map: Record<string, SpecItem[]> = {};
+    for (const item of items) {
+      if (!map[item.group_id]) map[item.group_id] = [];
+      map[item.group_id].push(item);
     }
-    (async () => {
-      setError('');
-      const { data, error } = await supabase
-        .from('motos')
-        .select('model_name')
-        .eq('brand_id', selectedBrandId)
-        .not('model_name', 'is', null)
-        .order('model_name', { ascending: true });
+    return map;
+  }, [items]);
 
-      if (error) return setError(error.message);
-
-      // dédoublonner côté client
-      const unique = Array.from(
-        new Set((data ?? []).map((r: any) => String(r.model_name)))
-      );
-      setModels(unique);
-      setSelectedModelName('');
-    })();
-  }, [selectedBrandId]);
-
-  // Ajouter la moto choisie
-  const onCompare = async () => {
-    setError('');
-    if (!selectedBrandId || !selectedModelName) {
-      setError("Choisis d'abord une marque et un modèle.");
-      return;
-    }
-
-    const { data, error } = await supabase
-      .from('motos')
-      .select('id,brand_id,model_name,year,price_tnd')
-      .eq('brand_id', selectedBrandId)
-      .eq('model_name', selectedModelName)
-      .limit(1)
-      .maybeSingle();
-
-    if (error) return setError(error.message);
-    if (!data) return setError("Aucune moto trouvée pour cette marque et ce modèle.");
-
-    setItems((prev) => (prev.some((x) => x.id === data.id) ? prev : [...prev, data]));
-  };
-
-  const reset = () => {
-    setSelectedBrandId('');
-    setSelectedModelName('');
-    setModels([]);
-    setError('');
-    setItems([]);
-  };
-
-  const ready = useMemo(
-    () => !!selectedBrandId && !!selectedModelName,
-    [selectedBrandId, selectedModelName]
-  );
+  if (loading) return <div className="p-4">Chargement…</div>;
+  if (error) return <div className="p-4 text-red-500">{error}</div>;
+  if (groups.length === 0) return <div className="p-4">Aucune caractéristique définie.</div>;
 
   return (
-    <div className="mx-auto max-w-4xl p-4">
-      <h1 className="text-2xl font-semibold mb-6">Comparateur de motos</h1>
-
-      <div className="grid md:grid-cols-3 gap-3 items-end">
-        {/* Marque */}
-        <div>
-          <label className="block text-sm mb-1">Marque</label>
-          <select
-            className="w-full rounded-md border px-3 py-2 bg-white text-black"
-            value={selectedBrandId}
-            onChange={(e) => setSelectedBrandId(e.target.value)}
-          >
-            <option value="">Sélectionner…</option>
-            {brands.map((b) => (
-              <option key={b.id} value={b.id}>{b.name}</option>
-            ))}
-          </select>
-        </div>
-
-        {/* Modèle (depuis motos.model_name) */}
-        <div>
-          <label className="block text-sm mb-1">Modèle</label>
-          <select
-            className="w-full rounded-md border px-3 py-2 bg-white text-black"
-            value={selectedModelName}
-            onChange={(e) => setSelectedModelName(e.target.value)}
-            disabled={!selectedBrandId}
-          >
-            <option value="">
-              {selectedBrandId ? 'Sélectionner…' : 'Choisis une marque d’abord'}
-            </option>
-            {models.map((name) => (
-              <option key={name} value={name}>{name}</option>
-            ))}
-          </select>
-        </div>
-
-        {/* Actions */}
-        <div className="flex gap-2">
-          <button
-            onClick={onCompare}
-            disabled={!ready}
-            className="rounded-md px-4 py-2 bg-emerald-600 text-white disabled:opacity-50"
-          >
-            Comparer
-          </button>
-          <button
-            onClick={reset}
-            className="rounded-md px-4 py-2 bg-gray-700 text-white"
-          >
-            Réinitialiser
-          </button>
-        </div>
-      </div>
-
-      {error && <p className="text-red-500 mt-3">{error}</p>}
-
-      {/* Résultats */}
-      <div className="mt-6 grid md:grid-cols-2 gap-4">
-        {items.map((m) => (
-          <div key={m.id} className="rounded-xl border p-4 bg-white text-black">
-            <div className="font-medium">{m.model_name}</div>
-            <div className="text-sm opacity-80">Année: {m.year ?? '—'}</div>
-            <div className="text-sm opacity-80">Prix: {m.price_tnd ?? '—'} TND</div>
+    <div className="grid md:grid-cols-2 gap-6 p-4">
+      <div>
+        {groups.map((group) => (
+          <div key={group.id} className="mb-4">
+            <h2 className="font-semibold">{group.name}</h2>
+            <ul className="mt-1 ml-4 space-y-1 text-sm">
+              {itemsByGroup[group.id]?.length ? (
+                itemsByGroup[group.id].map((item) => (
+                  <li key={item.id}>
+                    <div>{item.label}</div>
+                    {item.unit && (
+                      <div className="text-xs text-gray-500">{item.unit}</div>
+                    )}
+                  </li>
+                ))
+              ) : (
+                <li className="italic text-gray-500">
+                  — Aucune sous-caractéristique —
+                </li>
+              )}
+            </ul>
           </div>
         ))}
       </div>
+      <div>(valeurs à venir)</div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add client-side comparator page that lists spec groups and items

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm run typecheck` *(fails: Cannot find module '@supabase/ssr' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68b4944d04dc832ba581a0ff92004e0f