### PR TITLE
feat: add single moto comparator

### DIFF
--- a/src/app/comparateur/page.tsx
+++ b/src/app/comparateur/page.tsx
@@ -1,110 +1,287 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
-import { createClient } from '@supabase/supabase-js';
+ import { createClient } from '@supabase/supabase-js';
+ import { Fragment, useEffect, useMemo, useState } from 'react';
 
-interface SpecGroup {
-  id: string;
-  name: string;
-  sort_order: number | null;
-}
+ interface SpecGroup {
+   id: string;
+   name: string;
+   sort_order: number | null;
+ }
 
-interface SpecItem {
-  id: string;
-  group_id: string;
-  key: string | null;
-  label: string;
-  unit: string | null;
-  sort_order: number | null;
-}
+ interface SpecItem {
+   id: string;
+   group_id: string;
+   key: string | null;
+   label: string;
+   unit: string | null;
+   sort_order: number | null;
+ }
 
-export default function ComparatorPage() {
-  const [groups, setGroups] = useState<SpecGroup[]>([]);
-  const [items, setItems] = useState<SpecItem[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+ interface Brand {
+   id: string;
+   name: string;
+ }
 
-  useEffect(() => {
-    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-    const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+ interface Moto {
+   id: string;
+   brand_name: string | null;
+   model_name: string;
+   year: number | null;
+ }
 
-    if (!url || !anon) {
-      setError('Variables NEXT_PUBLIC_SUPABASE_URL ou NEXT_PUBLIC_SUPABASE_ANON_KEY manquantes.');
-      setLoading(false);
-      return;
-    }
+ interface SpecValue {
+   value_text: string | null;
+   value_number: number | null;
+   value_boolean: boolean | null;
+   value_json: unknown;
+   unit_override: string | null;
+ }
 
-    const supabase = createClient(url, anon);
+ export default function ComparatorPage() {
+   const [groups, setGroups] = useState<SpecGroup[]>([]);
+   const [items, setItems] = useState<SpecItem[]>([]);
+   const [brands, setBrands] = useState<Brand[]>([]);
+   const [models, setModels] = useState<Moto[]>([]);
+   const [selectedBrand, setSelectedBrand] = useState<string>('');
+   const [selectedMotoId, setSelectedMotoId] = useState<string>('');
+   const [specMap, setSpecMap] = useState<Record<string, SpecValue>>({});
+   const [loading, setLoading] = useState(true);
+   const [loadingModels, setLoadingModels] = useState(false);
+   const [loadingValues, setLoadingValues] = useState(false);
+   const [error, setError] = useState<string | null>(null);
 
-    (async () => {
-      try {
-        const [groupsRes, itemsRes] = await Promise.all([
-          supabase
-            .from('spec_groups')
-            .select('id,name,sort_order')
-            .order('sort_order', { ascending: true, nullsFirst: false })
-            .order('name', { ascending: true }),
-          supabase
-            .from('spec_items')
-            .select('id,group_id,key,label,unit,sort_order')
-            .order('group_id', { ascending: true })
-            .order('sort_order', { ascending: true, nullsFirst: false })
-            .order('label', { ascending: true }),
-        ]);
+   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+   const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+   const supabase = useMemo(() => {
+     if (!url || !anon) return null;
+     return createClient(url, anon);
+   }, [url, anon]);
 
-        if (groupsRes.error) throw groupsRes.error;
-        if (itemsRes.error) throw itemsRes.error;
+   useEffect(() => {
+     if (!supabase) {
+       setError(
+         'Variables NEXT_PUBLIC_SUPABASE_URL ou NEXT_PUBLIC_SUPABASE_ANON_KEY manquantes.'
+       );
+       setLoading(false);
+       return;
+     }
+     (async () => {
+       try {
+         const [groupsRes, itemsRes, brandsRes] = await Promise.all([
+           supabase
+             .from('spec_groups')
+             .select('id,name,sort_order')
+             .order('sort_order', { ascending: true, nullsFirst: false })
+             .order('name', { ascending: true }),
+           supabase
+             .from('spec_items')
+             .select('id,group_id,key,label,unit,sort_order')
+             .order('sort_order', { ascending: true, nullsFirst: false })
+             .order('label', { ascending: true }),
+           supabase.from('brands').select('id,name').order('name', {
+             ascending: true,
+           }),
+         ]);
 
-        setGroups(groupsRes.data ?? []);
-        setItems(itemsRes.data ?? []);
-      } catch (e: any) {
-        setError(e.message ?? 'Erreur inattendue');
-      } finally {
-        setLoading(false);
-      }
-    })();
-  }, []);
+         if (groupsRes.error) throw groupsRes.error;
+         if (itemsRes.error) throw itemsRes.error;
+         if (brandsRes.error) throw brandsRes.error;
 
-  const itemsByGroup = useMemo(() => {
-    const map: Record<string, SpecItem[]> = {};
-    for (const item of items) {
-      if (!map[item.group_id]) map[item.group_id] = [];
-      map[item.group_id].push(item);
-    }
-    return map;
-  }, [items]);
+         setGroups(groupsRes.data ?? []);
+         setItems(itemsRes.data ?? []);
+         setBrands(brandsRes.data ?? []);
+       } catch (e: any) {
+         setError(e.message ?? 'Erreur inattendue');
+       } finally {
+         setLoading(false);
+       }
+     })();
+   }, [supabase]);
 
-  if (loading) return <div className="p-4">Chargement…</div>;
-  if (error) return <div className="p-4 text-red-500">{error}</div>;
-  if (groups.length === 0) return <div className="p-4">Aucune caractéristique définie.</div>;
+   const itemsByGroup = useMemo(() => {
+     const map: Record<string, SpecItem[]> = {};
+     for (const item of items) {
+       if (!map[item.group_id]) map[item.group_id] = [];
+       map[item.group_id].push(item);
+     }
+     return map;
+   }, [items]);
 
-  return (
-    <div className="grid md:grid-cols-2 gap-6 p-4">
-      <div>
-        {groups.map((group) => (
-          <div key={group.id} className="mb-4">
-            <h2 className="font-semibold">{group.name}</h2>
-            <ul className="mt-1 ml-4 space-y-1 text-sm">
-              {itemsByGroup[group.id]?.length ? (
-                itemsByGroup[group.id].map((item) => (
-                  <li key={item.id}>
-                    <div>{item.label}</div>
-                    {item.unit && (
-                      <div className="text-xs text-gray-500">{item.unit}</div>
-                    )}
-                  </li>
-                ))
-              ) : (
-                <li className="italic text-gray-500">
-                  — Aucune sous-caractéristique —
-                </li>
-              )}
-            </ul>
-          </div>
-        ))}
-      </div>
-      <div>(valeurs à venir)</div>
-    </div>
-  );
-}
+   const selectedMoto = useMemo(
+     () => models.find((m) => m.id === selectedMotoId) || null,
+     [models, selectedMotoId]
+   );
+
+   const handleBrandChange = async (id: string) => {
+     setSelectedBrand(id);
+     setSelectedMotoId('');
+     setModels([]);
+     setSpecMap({});
+     if (!id || !supabase) return;
+     setLoadingModels(true);
+     try {
+       const res = await supabase
+         .from('motos')
+         .select('id,model_name,year,brand_name')
+         .eq('brand_id', id);
+       if (res.error) throw res.error;
+       setModels(res.data ?? []);
+     } catch (e: any) {
+       setError(e.message ?? 'Erreur inattendue');
+     } finally {
+       setLoadingModels(false);
+     }
+   };
+
+   const handleModelChange = async (id: string) => {
+     setSelectedMotoId(id);
+     setSpecMap({});
+     if (!id || !supabase) return;
+     setLoadingValues(true);
+     try {
+       const res = await supabase
+         .from('moto_spec_values')
+         .select(
+           'moto_id,spec_item_id,value_text,value_number,value_boolean,value_json,unit_override'
+         )
+         .eq('moto_id', id);
+       if (res.error) throw res.error;
+       const map: Record<string, SpecValue> = {};
+       for (const row of res.data ?? []) {
+         map[row.spec_item_id] = {
+           value_text: row.value_text,
+           value_number: row.value_number,
+           value_boolean: row.value_boolean,
+           value_json: row.value_json,
+           unit_override: row.unit_override,
+         };
+       }
+       setSpecMap(map);
+     } catch (e: any) {
+       setError(e.message ?? 'Erreur inattendue');
+     } finally {
+       setLoadingValues(false);
+     }
+   };
+
+   const renderValue = (item: SpecItem) => {
+     const v = specMap[item.id];
+     if (!v) return '—';
+     if (v.value_text) return v.value_text;
+     if (v.value_number != null) {
+       const unit = v.unit_override || item.unit;
+       return unit ? `${v.value_number} ${unit}` : String(v.value_number);
+     }
+     if (v.value_boolean != null) return v.value_boolean ? 'Oui' : 'Non';
+     if (v.value_json != null) return JSON.stringify(v.value_json);
+     return '—';
+   };
+
+   if (loading) return <div className="p-4">Chargement…</div>;
+   if (error) return <div className="p-4 text-red-500">{error}</div>;
+   if (groups.length === 0)
+     return <div className="p-4">Aucune caractéristique définie.</div>;
+
+  const rightHeader = !selectedBrand
+    ? 'Choisis une marque, puis un modèle.'
+    : !selectedMoto
+    ? 'Choisis un modèle.'
+    : loadingValues
+    ? 'Chargement…'
+    : error
+    ? 'Erreur de chargement'
+    : `${selectedMoto.brand_name ||
+        brands.find((b) => b.id === selectedBrand)?.name || ''} — ${
+        selectedMoto.model_name
+      }${selectedMoto.year ? ` ${selectedMoto.year}` : ''}`;
+
+   return (
+     <div className="p-4 space-y-4">
+       <div className="flex gap-4 sticky top-0 bg-background py-2">
+         <select
+           aria-label="Marque"
+           value={selectedBrand}
+           onChange={(e) => handleBrandChange(e.target.value)}
+           className="border p-2 rounded"
+         >
+           <option value="">Sélectionner une marque</option>
+           {brands.map((b) => (
+             <option key={b.id} value={b.id}>
+               {b.name}
+             </option>
+           ))}
+         </select>
+         <select
+           aria-label="Modèle"
+           value={selectedMotoId}
+           onChange={(e) => handleModelChange(e.target.value)}
+           disabled={!selectedBrand || loadingModels}
+           className="border p-2 rounded"
+         >
+           <option value="">Sélectionner un modèle</option>
+           {models.map((m) => (
+             <option key={m.id} value={m.id}>
+               {m.model_name}
+               {m.year ? ` ${m.year}` : ''}
+             </option>
+           ))}
+         </select>
+       </div>
+       <div className="overflow-auto">
+         <table className="min-w-full text-sm">
+           <thead className="sticky top-0 bg-background">
+             <tr>
+               <th className="text-left p-2 sticky left-0 bg-background z-10">
+                 Spécifications
+               </th>
+               <th className="text-left p-2">{rightHeader}</th>
+             </tr>
+           </thead>
+           <tbody>
+             {groups.map((group) => (
+               <Fragment key={group.id}>
+                 <tr className="bg-muted font-semibold">
+                   <th
+                     colSpan={2}
+                     className="text-left p-2 sticky left-0 bg-muted z-10"
+                   >
+                     {group.name}
+                   </th>
+                 </tr>
+                 {itemsByGroup[group.id]?.length ? (
+                   itemsByGroup[group.id].map((item) => {
+                     const value = renderValue(item);
+                     return (
+                       <tr key={item.id} className="border-b">
+                         <th className="text-left p-2 font-medium sticky left-0 bg-background z-10">
+                           {item.label}
+                           {item.unit && (
+                             <span className="ml-1 text-xs text-muted-foreground">
+                               {item.unit}
+                             </span>
+                           )}
+                         </th>
+                         <td className="p-2" title={value}>
+                           {value}
+                         </td>
+                       </tr>
+                     );
+                   })
+                 ) : (
+                   <tr className="border-b">
+                     <th className="italic text-muted-foreground p-2 text-left sticky left-0 bg-background z-10">
+                       — Aucune sous-caractéristique —
+                     </th>
+                     <td className="p-2">—</td>
+                   </tr>
+                 )}
+               </Fragment>
+             ))}
+           </tbody>
+         </table>
+       </div>
+     </div>
+   );
+ }
 


### PR DESCRIPTION
## Summary
- implement brand and model selection flow and fetch corresponding moto spec values
- render single-moto comparison table with unit override and value priority

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next: not found)
- `npm run typecheck` (fails: Cannot find module 'react', etc.)

------
https://chatgpt.com/codex/tasks/task_e_68b49adb2dbc832bad906a18dc2c85f9