### PR TITLE
fix: sticky header on comparator table

### DIFF
--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -17,7 +17,7 @@ export default function CompareTable({ motos }: CompareTableProps) {
   return (
     <div className="overflow-x-auto">
       <table className="min-w-full text-sm">
-        <thead>
+        <thead className="sticky top-0 bg-background z-10">
           <tr>
             <th className="p-2 text-left">Spécifications</th>
             {motos.map((m) => (


### PR DESCRIPTION
## Summary
- keep specification and model name header row fixed while scrolling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found, dependencies not installed)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a49264a0832bb26cecdeb821e9ec