### PR TITLE
fix: show moto specs on detail page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .env
 .env.*
 !.env.example
+tsconfig.tsbuildinfo

--- a/src/lib/db/motos.ts
+++ b/src/lib/db/motos.ts
@@ -25,10 +25,39 @@ export async function fetchMotoCards(limit = 24): Promise<MotoCard[]> {
 }
 
 export async function fetchMotoFull(motoId: string): Promise<any> {
-  const { data, error } = await supabase
-    .rpc('fn_get_moto_full', { p_moto_id: motoId })
+  const { data, error } = await supabase.rpc('fn_get_moto_full', {
+    p_moto_id: motoId,
+  })
   if (error) throw error
-  return data // JSON complet (brand, model, price_tnd, images[], specs[])
+  if (!data) return null
+
+  // L'RPC peut renvoyer un objet imbriqué { moto: {...}, specs: [...] }
+  // ou un objet plat directement exploitable. On normalise ici pour que la
+  // page détail reçoive toujours {brand, model, year, price_tnd, images, specs}.
+  let payload: any = data
+
+  if (typeof payload === 'string') {
+    try {
+      payload = JSON.parse(payload)
+    } catch {
+      payload = null
+    }
+  }
+
+  if (Array.isArray(payload)) {
+    payload = payload[0] ?? null
+  }
+
+  if (!payload) return null
+
+  const moto = 'moto' in payload ? payload.moto : payload
+
+  return {
+    ...moto,
+    price_tnd: moto.price_tnd ?? moto.price ?? null,
+    images: payload.images ?? moto.images ?? [],
+    specs: payload.specs ?? payload.groups ?? [],
+  }
 }
 
 export function formatTND(v?: number | null) {


### PR DESCRIPTION
## Summary
- normalize RPC result when fetching moto details so page receives brand, price and specs consistently
- ignore TypeScript build info file

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next: not found)
- `npm run typecheck` (fails: Cannot find module '@supabase/ssr')

------
https://chatgpt.com/codex/tasks/task_e_68b4ce137428832bb7084db1ab3accd8