### PR TITLE
Display full motorcycle details from Supabase

### DIFF
--- a/src/app/moto/[id]/page.tsx
+++ b/src/app/moto/[id]/page.tsx
@@ -29,13 +29,36 @@ export default async function MotoPage({ params }: { params: { id: string } }) {
         </div>
       </header>
 
+      {fiche.images?.length ? (
+        <section className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+          {fiche.images.map((img) => (
+            <Image
+              key={img.id}
+              src={img.url}
+              alt={img.alt ?? `${fiche.moto.brand} ${fiche.moto.model}`}
+              width={400}
+              height={300}
+              className="w-full h-auto object-cover rounded"
+            />
+          ))}
+        </section>
+      ) : null}
+
       <section className="space-y-6">
         {fiche.specs?.map((grp) => (
           <div key={grp.group} className="rounded-2xl border p-4">
             <h2 className="text-lg font-medium mb-3">{grp.group}</h2>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
               {grp.items?.map((it, idx) => {
-                const raw = it.value_text ?? it.value_number ?? (typeof it.value_boolean === 'boolean' ? (it.value_boolean ? 'Oui' : 'Non') : null) ?? (it.value_json ? JSON.stringify(it.value_json) : '');
+                const raw =
+                  it.value_text ??
+                  it.value_number ??
+                  (typeof it.value_boolean === 'boolean'
+                    ? it.value_boolean
+                      ? 'Oui'
+                      : 'Non'
+                    : null) ??
+                  (it.value_json ? JSON.stringify(it.value_json) : '');
                 const val = [raw, it.unit].filter(Boolean).join(' ');
                 return (
                   <div key={it.key + idx} className="flex justify-between gap-4 border-b py-2">

--- a/src/lib/getMotoFull.ts
+++ b/src/lib/getMotoFull.ts
@@ -2,13 +2,77 @@ import { supabase } from './supabaseClient';
 
 export type MotoFull = {
   moto: { id: string; brand: string; model: string; year: number; price?: number | null; display_image?: string | null } | null;
-  specs: { group: string; items: { key: string; label: string; unit: string | null; value_text?: string | null; value_number?: number | null; value_boolean?: boolean | null; value_json?: any }[] }[];
+  images: { id: string; url: string; alt: string | null; is_primary?: boolean | null }[];
+  specs: {
+    group: string;
+    items: {
+      key: string;
+      label: string;
+      unit: string | null;
+      value_text?: string | null;
+      value_number?: number | null;
+      value_boolean?: boolean | null;
+      value_json?: any;
+    }[];
+  }[];
 };
 
 export async function getMotoFull(motoId: string): Promise<MotoFull> {
-  const { data, error } = await supabase
-    .rpc('fn_get_moto_full', { p_moto_id: motoId });
+  const { data: moto, error: motoErr } = await supabase
+    .from('motos')
+    .select('id,brand,model,year,price,display_image')
+    .eq('id', motoId)
+    .single();
+  if (motoErr) throw motoErr;
 
-  if (error) throw error;
-  return (data as MotoFull) ?? { moto: null, specs: [] };
+  if (!moto) return { moto: null, images: [], specs: [] };
+
+  const { data: images, error: imgErr } = await supabase
+    .from('moto_images')
+    .select('id,url,alt,is_primary,sort_order')
+    .eq('moto_id', motoId)
+    .order('is_primary', { ascending: false })
+    .order('sort_order', { ascending: true });
+  if (imgErr) throw imgErr;
+
+  const { data: specRows, error: specErr } = await supabase
+    .from('spec_items')
+    .select(`
+      id,key,label,unit,sort_order,
+      spec_groups ( name, sort_order ),
+      moto_spec_values!inner ( value_text,value_number,value_boolean,value_json,unit_override )
+    `)
+    .eq('moto_spec_values.moto_id', motoId);
+  if (specErr) throw specErr;
+
+  const grouped: Record<string, { sort: number; items: any[] }> = {};
+  (specRows ?? []).forEach((row: any) => {
+    const grpName = row.spec_groups?.name ?? 'Autres';
+    const grpSort = row.spec_groups?.sort_order ?? 0;
+    const val = Array.isArray(row.moto_spec_values)
+      ? row.moto_spec_values[0]
+      : row.moto_spec_values;
+    if (!grouped[grpName]) grouped[grpName] = { sort: grpSort, items: [] };
+    grouped[grpName].items.push({
+      key: row.key,
+      label: row.label,
+      unit: val?.unit_override ?? row.unit ?? null,
+      value_text: val?.value_text ?? null,
+      value_number: val?.value_number ?? null,
+      value_boolean: val?.value_boolean ?? null,
+      value_json: val?.value_json ?? null,
+      sort_order: row.sort_order ?? 0,
+    });
+  });
+
+  const specs = Object.entries(grouped)
+    .sort((a, b) => a[1].sort - b[1].sort || a[0].localeCompare(b[0]))
+    .map(([group, info]) => ({
+      group,
+      items: info.items
+        .sort((a, b) => a.sort_order - b.sort_order || a.label.localeCompare(b.label))
+        .map(({ sort_order, ...rest }) => rest),
+    }));
+
+  return { moto, images: images ?? [], specs };
 }


### PR DESCRIPTION
## Summary
- load motorcycle details from `motos`, `moto_images`, and spec tables instead of RPC
- render gallery and specification groups on moto detail page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found; `npm ci` failed with 403)*
- `npm run typecheck` *(fails: many missing module errors due to failed install)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d4e5885c832b9e2768a6032f8ea5