### PR TITLE
Fix moto detail page to fetch all data from Supabase tables

### DIFF
--- a/src/app/moto/[id]/page.tsx
+++ b/src/app/moto/[id]/page.tsx
@@ -10,24 +10,31 @@ export default async function MotoPage({ params }: { params: { id: string } }) {
 
   return (
     <div className="max-w-5xl mx-auto p-6 space-y-8">
-      <header className="flex items-center gap-4">
-        {fiche.moto.display_image ? (
-          <Image
-            src={fiche.moto.display_image}
-            alt={`${fiche.moto.brand} ${fiche.moto.model}`}
-            width={220}
-            height={140}
-          />
-        ) : null}
-        <div>
-          <h1 className="text-2xl font-semibold">
-            {fiche.moto.brand} {fiche.moto.model} {fiche.moto.year}
-          </h1>
-          {typeof fiche.moto.price === 'number' ? (
-            <p className="opacity-70">{fiche.moto.price} TND</p>
-          ) : null}
-        </div>
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold">
+          {fiche.moto.brand_name} {fiche.moto.model_name} {fiche.moto.year}
+        </h1>
+        <p className="opacity-70">
+          {typeof fiche.moto.price_tnd === 'number'
+            ? `${fiche.moto.price_tnd} TND`
+            : '-'}
+        </p>
       </header>
+
+      {fiche.images.length > 0 && (
+        <section className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {fiche.images.map((img) => (
+            <Image
+              key={img.id}
+              src={img.image_url}
+              alt={img.alt ?? ''}
+              width={800}
+              height={600}
+              className="w-full h-auto rounded"
+            />
+          ))}
+        </section>
+      )}
 
       <section className="space-y-6">
         {fiche.specs?.map((grp) => (
@@ -35,10 +42,21 @@ export default async function MotoPage({ params }: { params: { id: string } }) {
             <h2 className="text-lg font-medium mb-3">{grp.group}</h2>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
               {grp.items?.map((it, idx) => {
-                const raw = it.value_text ?? it.value_number ?? (typeof it.value_boolean === 'boolean' ? (it.value_boolean ? 'Oui' : 'Non') : null) ?? (it.value_json ? JSON.stringify(it.value_json) : '');
-                const val = [raw, it.unit].filter(Boolean).join(' ');
+                const raw =
+                  it.value_text ??
+                  it.value_number ??
+                  (typeof it.value_boolean === 'boolean'
+                    ? it.value_boolean
+                      ? 'Oui'
+                      : 'Non'
+                    : null) ??
+                  (it.value_json ? JSON.stringify(it.value_json) : null);
+                const val = raw ? [raw, it.unit].filter(Boolean).join(' ') : '-';
                 return (
-                  <div key={it.key + idx} className="flex justify-between gap-4 border-b py-2">
+                  <div
+                    key={it.key + idx}
+                    className="flex justify-between gap-4 border-b py-2"
+                  >
                     <span className="opacity-70">{it.label}</span>
                     <span className="font-medium">{val}</span>
                   </div>

--- a/src/lib/getMotoFull.ts
+++ b/src/lib/getMotoFull.ts
@@ -1,14 +1,94 @@
 import { supabase } from './supabaseClient';
 
 export type MotoFull = {
-  moto: { id: string; brand: string; model: string; year: number; price?: number | null; display_image?: string | null } | null;
-  specs: { group: string; items: { key: string; label: string; unit: string | null; value_text?: string | null; value_number?: number | null; value_boolean?: boolean | null; value_json?: any }[] }[];
+  moto:
+    | {
+        id: string;
+        brand_id: string;
+        brand_name: string;
+        model_name: string;
+        year: number;
+        price_tnd?: number | null;
+      }
+    | null;
+  images: { id: string; image_url: string; alt: string | null }[];
+  specs: {
+    group: string;
+    items: {
+      key: string;
+      label: string;
+      unit: string | null;
+      value_text?: string | null;
+      value_number?: number | null;
+      value_boolean?: boolean | null;
+      value_json?: any;
+    }[];
+  }[];
 };
 
 export async function getMotoFull(motoId: string): Promise<MotoFull> {
-  const { data, error } = await supabase
-    .rpc('fn_get_moto_full', { p_moto_id: motoId });
+  const { data: moto, error: motoError } = await supabase
+    .from('motos')
+    .select('id,brand_id,brand_name,model_name,year,price_tnd')
+    .eq('id', motoId)
+    .maybeSingle();
 
-  if (error) throw error;
-  return (data as MotoFull) ?? { moto: null, specs: [] };
+  if (motoError) throw motoError;
+  if (!moto) return { moto: null, images: [], specs: [] };
+
+  const { data: images, error: imagesError } = await supabase
+    .from('moto_images')
+    .select('id,image_url,alt,sort_order,is_main,created_at')
+    .eq('moto_id', motoId)
+    .order('is_main', { ascending: false })
+    .order('sort_order', { ascending: true })
+    .order('created_at', { ascending: true });
+  if (imagesError) throw imagesError;
+
+  const { data: groups, error: groupsError } = await supabase
+    .from('spec_groups')
+    .select('id,name,sort_order')
+    .order('sort_order', { ascending: true });
+  if (groupsError) throw groupsError;
+
+  const { data: items, error: itemsError } = await supabase
+    .from('spec_items')
+    .select('id,key,label,group_id,unit,sort_order')
+    .order('sort_order', { ascending: true });
+  if (itemsError) throw itemsError;
+
+  const { data: values, error: valuesError } = await supabase
+    .from('moto_spec_values')
+    .select(
+      'spec_item_id,value_text,value_number,value_boolean,value_json,unit_override'
+    )
+    .eq('moto_id', motoId);
+  if (valuesError) throw valuesError;
+
+  const specs =
+    groups?.map((g) => {
+      const groupItems =
+        items
+          ?.filter((it) => it.group_id === g.id)
+          .map((it) => {
+            const val = values?.find((v) => v.spec_item_id === it.id);
+            return {
+              key: it.key,
+              label: it.label,
+              unit: val?.unit_override ?? it.unit ?? null,
+              value_text: val?.value_text ?? null,
+              value_number: val?.value_number ?? null,
+              value_boolean: val?.value_boolean ?? null,
+              value_json: val?.value_json ?? null,
+            };
+          }) ?? [];
+      return { group: g.name, items: groupItems };
+    })
+      ?.filter((grp) => grp.items.length > 0) ?? [];
+
+  return {
+    moto,
+    images: images?.map((im) => ({ id: im.id, image_url: im.image_url, alt: im.alt ?? null })) ?? [],
+    specs,
+  };
 }


### PR DESCRIPTION
## Summary
- fetch moto info, images and specs from Supabase tables in `getMotoFull`
- render brand, model, year, price and all images on moto detail page
- show `-` for missing spec values and avoid calls to non-existent RPC endpoints

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm run typecheck` *(fails: dependencies not found / tsc errors)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d9ea3afc832bb80447d66a921baf