### PR TITLE
fix moto details page with full specs

### DIFF
--- a/src/lib/db/motos.ts
+++ b/src/lib/db/motos.ts
@@ -1,8 +1,4 @@
-import { createClient } from '@supabase/supabase-js'
-
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-const supabase = createClient(supabaseUrl, supabaseKey)
+import { supabase } from '@/lib/supabaseClient'
 
 export type MotoCard = {
   id: string
@@ -24,11 +20,21 @@ export async function fetchMotoCards(limit = 24): Promise<MotoCard[]> {
   return data as MotoCard[]
 }
 
-export async function fetchMotoFull(motoId: string): Promise<any> {
-  const { data, error } = await supabase
-    .rpc('fn_get_moto_full', { p_moto_id: motoId })
-  if (error) throw error
-  return data // JSON complet (brand, model, price_tnd, images[], specs[])
+export async function getMotoFull(id: string): Promise<any> {
+  const { data, error } = await supabase.rpc('fn_get_moto_full', {
+    p_moto_id: id,
+  })
+
+  if (error) {
+    console.error('getMotoFull error', error)
+    throw new Error('MOTO_NOT_FOUND')
+  }
+
+  if (!data) {
+    throw new Error('MOTO_NOT_FOUND')
+  }
+
+  return data
 }
 
 export function formatTND(v?: number | null) {

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,6 +1,16 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 
-export const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+
+// Ensure Supabase client is created only once
+let client: SupabaseClient
+
+if (!(globalThis as any).__supabase) {
+  ;(globalThis as any).__supabase = createClient(url, key)
+}
+
+client = (globalThis as any).__supabase as SupabaseClient
+
+export const supabase = client
+


### PR DESCRIPTION
## Summary
- ensure singleton Supabase client
- add `getMotoFull` RPC helper
- render full moto detail page with images and grouped specs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b4f26714cc832b9552685ebb63f213