### PR TITLE
feat: display moto images with public URLs

### DIFF
--- a/src/app/motos/[id]/page.tsx
+++ b/src/app/motos/[id]/page.tsx
@@ -1,6 +1,6 @@
-import Image from 'next/image'
 import { getMotoFull, formatTND } from '@/lib/db/motos'
-import { supabase } from '@/lib/supabaseClient'
+import getPublicImageUrl from '@/lib/getPublicImageUrl'
+import MotoImage from '@/components/MotoImage'
 
 export default async function MotoDetailPage({ params }: { params: { id: string } }) {
   let moto: any
@@ -17,13 +17,6 @@ export default async function MotoDetailPage({ params }: { params: { id: string 
 
   const title = `${moto.brand ?? ''} ${moto.model ?? ''} ${moto.year ?? ''}`.trim()
 
-  const resolveUrl = (url?: string | null) => {
-    if (!url) return ''
-    if (url.startsWith('http')) return url
-    const { data } = supabase.storage.from('motos').getPublicUrl(url)
-    return data.publicUrl || url
-  }
-
   return (
     <div className="max-w-6xl mx-auto">
       <header className="sticky top-0 z-10 bg-white p-6 shadow">
@@ -34,21 +27,17 @@ export default async function MotoDetailPage({ params }: { params: { id: string 
       {Array.isArray(moto.images) && moto.images.length > 0 && (
         <section className="p-6 grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
           {moto.images.map((img: any, idx: number) => {
-            const src = resolveUrl(img.url)
+            const src = getPublicImageUrl(img.url)
             return (
               <div key={idx} className="relative aspect-square rounded-xl overflow-hidden border">
-                {src ? (
-                  <Image
-                    src={src}
-                    alt={img.alt ?? title}
-                    fill
-                    className="object-contain bg-white"
-                    sizes="(max-width: 768px) 50vw, (max-width: 1200px) 33vw, 25vw"
-                    unoptimized
-                  />
-                ) : (
-                  <div className="w-full h-full grid place-items-center text-gray-400">Image indisponible</div>
-                )}
+                <MotoImage
+                  src={src}
+                  alt={img.alt ?? title}
+                  fill
+                  className="object-contain bg-white"
+                  sizes="(max-width: 768px) 50vw, (max-width: 1200px) 33vw, 25vw"
+                  unoptimized
+                />
               </div>
             )
           })}

--- a/src/components/MotoImage.tsx
+++ b/src/components/MotoImage.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import Image, { ImageProps } from "next/image";
+import { useState } from "react";
+
+interface MotoImageProps extends Omit<ImageProps, "src" | "alt"> {
+  src: string;
+  alt: string;
+}
+
+export function MotoImage({ src, alt, ...props }: MotoImageProps) {
+  const [error, setError] = useState(false);
+
+  if (!src || error) {
+    return <div className={`w-full h-full bg-gray-200 ${props.className ?? ""}`} />;
+  }
+
+  return (
+    <Image
+      src={src}
+      alt={alt}
+      onError={() => setError(true)}
+      {...props}
+    />
+  );
+}
+
+export default MotoImage;

--- a/src/lib/getPublicImageUrl.ts
+++ b/src/lib/getPublicImageUrl.ts
@@ -1,0 +1,21 @@
+import { supabase } from './supabaseClient';
+
+/**
+ * Resolve a public URL for a moto image stored in Supabase storage.
+ * Accepts absolute URLs and returns them unchanged.
+ * For relative paths, it removes a leading `motos/` segment then
+ * uses Supabase to generate a public URL with a fallback to the
+ * environment base URL.
+ */
+export function getPublicImageUrl(path: string): string {
+  if (!path) return '';
+  if (path.startsWith('http')) return path;
+  const removePrefix = path.replace(/^motos\//, '');
+  const { data } = supabase.storage.from('motos').getPublicUrl(removePrefix);
+  return (
+    data?.publicUrl ??
+    `${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/motos/${removePrefix}`
+  );
+}
+
+export default getPublicImageUrl;


### PR DESCRIPTION
## Summary
- add `getPublicImageUrl` helper for Supabase storage
- add `MotoImage` component with placeholder on error
- use helper/component on moto detail page to show images without admin RPC

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm run typecheck` *(fails: cannot find module '@supabase/ssr', missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f51e3e1c832bb121b95ee0a7d297