### PR TITLE
feat: add dynamic moto filters

### DIFF
--- a/src/app/motos/page.tsx
+++ b/src/app/motos/page.tsx
@@ -1,23 +1,175 @@
-import { createClient } from '@supabase/supabase-js';
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import MotoCard from '@/components/MotoCard';
+import FiltersPanel from '@/components/FiltersPanel';
+import { useMotoFacets } from '@/hooks/useMotoFacets';
+import { useMotoSearch } from '@/hooks/useMotoSearch';
+import { Filters } from '@/types/filters';
+import { encodeState, decodeState } from '@/lib/urlState';
+import { Drawer, DrawerTrigger, DrawerContent } from '@/components/ui/drawer';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { X } from 'lucide-react';
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
+function findFacetItem(facets: any[], key: string) {
+  for (const g of facets) {
+    const it = g.items.find((i: any) => i.key === key);
+    if (it) return it;
+  }
+  return null;
+}
 
-export default async function MotosPage() {
-  const { data, error } = await supabase
-    .from('v_moto_cards')
-    .select('id, brand, model, year, price:price_tnd, display_image:primary_image_path')
-    .order('brand', { ascending: true })
-    .limit(60);
+export default function MotosPage() {
+  const searchParams = useSearchParams();
+  const initial = useMemo(() => decodeState(searchParams.get('f')), [searchParams]);
+  const [filters, setFilters] = useState<Filters>(initial?.filters || {});
+  const [page, setPage] = useState<number>(initial?.page || 0);
 
-  if (error) throw new Error(error.message);
+  const { facets } = useMotoFacets();
+  const { motos, loading, pageSize } = useMotoSearch(filters, page);
+
+  useEffect(() => {
+    const encoded = encodeState(filters, page);
+    const url = encoded ? `?f=${encoded}` : '';
+    window.history.replaceState(null, '', url);
+  }, [filters, page]);
+
+  const removeFilter = (key: string) => {
+    setFilters((prev) => {
+      const next = { ...prev } as Filters;
+      if (key === 'price' || key === 'year') {
+        delete (next as any)[key];
+      } else if (key === 'brand_ids') {
+        delete next.brand_ids;
+      } else if (next.specs) {
+        delete next.specs[key];
+        if (Object.keys(next.specs).length === 0) delete next.specs;
+      }
+      return next;
+    });
+    setPage(0);
+  };
+
+  const badges = useMemo(() => {
+    const items: { key: string; label: string }[] = [];
+    if (filters.price) {
+      const it = findFacetItem(facets, 'price');
+      items.push({
+        key: 'price',
+        label: `${it?.label ?? 'price'} ${filters.price.min ?? ''}–${filters.price.max ?? ''} ${it?.unit ?? ''}`.trim(),
+      });
+    }
+    if (filters.year) {
+      const it = findFacetItem(facets, 'year');
+      items.push({
+        key: 'year',
+        label: `${it?.label ?? 'year'} ${filters.year.min ?? ''}–${filters.year.max ?? ''} ${it?.unit ?? ''}`.trim(),
+      });
+    }
+    if (filters.brand_ids && filters.brand_ids.length) {
+      const it = findFacetItem(facets, 'brand_ids');
+      items.push({
+        key: 'brand_ids',
+        label: `${it?.label ?? 'brand'} ${filters.brand_ids.join(', ')}`,
+      });
+    }
+    if (filters.specs) {
+      Object.entries(filters.specs).forEach(([k, v]) => {
+        const it = findFacetItem(facets, k);
+        let value = '';
+        if (typeof v === 'boolean') value = v ? 'Oui' : 'Non';
+        else if (typeof v === 'string') value = v;
+        else if (Array.isArray(v)) value = v.join(', ');
+        else if (v && typeof v === 'object' && 'in' in v) value = (v.in as string[]).join(', ');
+        else if (v && typeof v === 'object')
+          value = `${(v as any).min ?? ''}–${(v as any).max ?? ''} ${it?.unit ?? ''}`.trim();
+        items.push({ key: k, label: `${it?.label ?? k} ${value}`.trim() });
+      });
+    }
+    return items;
+  }, [filters, facets]);
+
+  const resetAll = () => {
+    setFilters({});
+    setPage(0);
+  };
 
   return (
-    <div className="max-w-6xl mx-auto p-6 grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
-      {data?.map((m) => <MotoCard key={m.id} moto={m} />)}
+    <div className="flex">
+      <aside className="hidden md:block w-64 p-4 border-r">
+        <FiltersPanel
+          facets={facets}
+          filters={filters}
+          onChange={(f) => {
+            setFilters(f);
+            setPage(0);
+          }}
+          onReset={resetAll}
+        />
+      </aside>
+      <div className="flex-1 p-4">
+        <div className="md:hidden mb-4">
+          <Drawer>
+            <DrawerTrigger asChild>
+              <Button variant="outline">Filtres</Button>
+            </DrawerTrigger>
+            <DrawerContent className="p-4">
+              <FiltersPanel
+                facets={facets}
+                filters={filters}
+                onChange={(f) => {
+                  setFilters(f);
+                  setPage(0);
+                }}
+                onReset={resetAll}
+              />
+            </DrawerContent>
+          </Drawer>
+        </div>
+
+        {badges.length > 0 && (
+          <div className="flex flex-wrap gap-2 mb-4">
+            {badges.map((b) => (
+              <Button
+                key={b.key}
+                variant="secondary"
+                size="sm"
+                onClick={() => removeFilter(b.key)}
+              >
+                {b.label}
+                <X className="ml-1 h-3 w-3" />
+              </Button>
+            ))}
+          </div>
+        )}
+
+        {loading ? (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {Array.from({ length: 9 }).map((_, i) => (
+              <Skeleton key={i} className="h-60 w-full" />
+            ))}
+          </div>
+        ) : motos.length === 0 ? (
+          <div>Aucun résultat, essayez d’élargir les filtres</div>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {motos.map((m) => (
+              <MotoCard key={m.id} moto={m} />
+            ))}
+          </div>
+        )}
+
+        <div className="flex justify-between mt-4">
+          <Button disabled={page === 0} onClick={() => setPage((p) => Math.max(0, p - 1))}>
+            Précédent
+          </Button>
+          <Button disabled={motos.length < pageSize} onClick={() => setPage((p) => p + 1)}>
+            Suivant
+          </Button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/FiltersPanel.tsx
+++ b/src/components/FiltersPanel.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { FacetGroup, Filters, Range } from '@/types/filters';
+import { Slider } from '@/components/ui/slider';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { Button } from '@/components/ui/button';
+import { useMemo } from 'react';
+
+interface FiltersPanelProps {
+  facets: FacetGroup[];
+  filters: Filters;
+  onChange: (next: Filters) => void;
+  onReset: () => void;
+}
+
+export default function FiltersPanel({ facets, filters, onChange, onReset }: FiltersPanelProps) {
+  const current = useMemo(() => filters, [filters]);
+
+  const update = (key: string, value: any) => {
+    const next: Filters = { ...current };
+    if (key === 'price' || key === 'year') {
+      if (!value || (value.min === undefined && value.max === undefined)) delete (next as any)[key];
+      else (next as any)[key] = value;
+    } else if (key === 'brand_ids') {
+      if (!value || value.length === 0) delete next.brand_ids;
+      else next.brand_ids = value;
+    } else {
+      next.specs = { ...(next.specs || {}) };
+      if (value === undefined || (Array.isArray(value) && value.length === 0)) {
+        delete next.specs[key];
+        if (Object.keys(next.specs).length === 0) delete next.specs;
+      } else {
+        next.specs[key] = value;
+      }
+    }
+    onChange(next);
+  };
+
+  const renderNumber = (item: any) => {
+    const range = (current as any)[item.key] as Range | undefined;
+    const min = range?.min ?? item.min;
+    const max = range?.max ?? item.max;
+    return (
+      <div className="space-y-2" key={item.key}>
+        <Slider
+          value={[min ?? 0, max ?? 0]}
+          min={item.min}
+          max={item.max}
+          step={1}
+          onValueChange={(v) => update(item.key, { min: v[0], max: v[1] })}
+          aria-label={`${item.label} ${item.unit ?? ''}`}
+        />
+        <div className="flex gap-2">
+          <Input
+            type="number"
+            value={min ?? ''}
+            onChange={(e) => update(item.key, { min: Number(e.target.value), max })}
+            aria-label={`Min ${item.label}`}
+          />
+          <Input
+            type="number"
+            value={max ?? ''}
+            onChange={(e) => update(item.key, { min, max: Number(e.target.value) })}
+            aria-label={`Max ${item.label}`}
+          />
+          {item.unit && <span className="self-center text-sm opacity-70">{item.unit}</span>}
+        </div>
+      </div>
+    );
+  };
+
+  const renderBoolean = (item: any) => {
+    const value = (current.specs as any)?.[item.key];
+    return (
+      <ToggleGroup
+        type="single"
+        value={value === true ? 'true' : value === false ? 'false' : ''}
+        onValueChange={(val) => update(item.key, val === '' ? undefined : val === 'true')}
+        className="flex gap-1"
+      >
+        <ToggleGroupItem value="" aria-label={`Tous ${item.label}`}>Tous</ToggleGroupItem>
+        <ToggleGroupItem value="true" aria-label={`${item.label} Oui`}>Oui</ToggleGroupItem>
+        <ToggleGroupItem value="false" aria-label={`${item.label} Non`}>Non</ToggleGroupItem>
+      </ToggleGroup>
+    );
+  };
+
+  const renderEnum = (item: any) => {
+    const selected = (() => {
+      if (item.key === 'brand_ids') return current.brand_ids || [];
+      const spec = current.specs?.[item.key];
+      if (Array.isArray(spec)) return spec;
+      if (spec && typeof spec === 'object' && 'in' in spec) return spec.in as string[];
+      return [];
+    })();
+
+    const toggle = (val: string, checked: boolean) => {
+      const next = checked ? [...selected, val] : selected.filter((v) => v !== val);
+      if (item.key === 'brand_ids') update(item.key, next);
+      else update(item.key, next.length ? { in: next } : undefined);
+    };
+
+    return (
+      <div className="space-y-1">
+        {item.dist_text?.map((d: any) => (
+          <label key={d.value} className="flex items-center gap-2">
+            <Checkbox
+              checked={selected.includes(d.value)}
+              onCheckedChange={(c) => toggle(d.value, !!c)}
+            />
+            <span className="text-sm">{d.value}</span>
+          </label>
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-between items-center">
+        <h3 className="font-semibold">Filtres</h3>
+        <Button variant="ghost" onClick={onReset} className="text-sm">Réinitialiser</Button>
+      </div>
+      {facets.map((group) => (
+        <div key={group.key} className="space-y-2">
+          <h4 className="font-medium text-sm">{group.label}</h4>
+          {group.items.map((item) => (
+            <div key={item.key} className="space-y-2">
+              <label className="text-sm font-medium">{item.label}</label>
+              {item.type === 'number'
+                ? renderNumber(item)
+                : item.type === 'boolean'
+                ? renderBoolean(item)
+                : renderEnum(item)}
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/useMotoFacets.ts
+++ b/src/hooks/useMotoFacets.ts
@@ -1,0 +1,74 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { FacetGroup } from '@/types/filters';
+import { toast } from '@/hooks/use-toast';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+export function useMotoFacets() {
+  const [facets, setFacets] = useState<FacetGroup[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const fetchFacets = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(
+          `${SUPABASE_URL}/rest/v1/rpc/fn_get_filter_facets`,
+          {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${ANON_KEY}`,
+              'Content-Type': 'application/json',
+            },
+            body: '{}',
+          }
+        );
+        if (!res.ok) {
+          throw new Error(await res.text());
+        }
+        const json = await res.json();
+        const groups: FacetGroup[] = (Array.isArray(json)
+          ? json
+          : Object.values(json))
+          .map((g: any) => ({
+            key: g.key || g.group_key || g.name,
+            label: g.label || g.group_label || g.name,
+            group_sort: g.group_sort,
+            items: (g.items || []).map((i: any) => ({
+              key: i.key,
+              label: i.label,
+              unit: i.unit,
+              type: i.type,
+              min: i.min,
+              max: i.max,
+              dist_bool: i.dist_bool,
+              dist_text: i.dist_text,
+              item_sort: i.item_sort,
+            }))
+              .sort((a: any, b: any) =>
+                (a.item_sort ?? 0) - (b.item_sort ?? 0) || a.label.localeCompare(b.label)
+              ),
+          }))
+          .sort((a: any, b: any) =>
+            (a.group_sort ?? 0) - (b.group_sort ?? 0) || a.label.localeCompare(b.label)
+          );
+        setFacets(groups);
+      } catch (err) {
+        const e = err as Error;
+        setError(e);
+        toast({ description: e.message });
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchFacets();
+  }, []);
+
+  return { facets, loading, error };
+}

--- a/src/hooks/useMotoSearch.ts
+++ b/src/hooks/useMotoSearch.ts
@@ -1,0 +1,59 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Filters } from '@/types/filters';
+import { toast } from '@/hooks/use-toast';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+const PAGE_SIZE = 24;
+
+export function useMotoSearch(filters: Filters, page: number) {
+  const [motos, setMotos] = useState<any[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let aborted = false;
+    const search = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(
+          `${SUPABASE_URL}/rest/v1/rpc/fn_search_motos`,
+          {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${ANON_KEY}`,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              p_filters: filters,
+              p_limit: PAGE_SIZE,
+              p_offset: page * PAGE_SIZE,
+            }),
+          }
+        );
+        if (!res.ok) {
+          throw new Error(await res.text());
+        }
+        const json = await res.json();
+        if (!aborted) setMotos(Array.isArray(json) ? json : []);
+      } catch (err) {
+        const e = err as Error;
+        if (!aborted) {
+          setError(e);
+          toast({ description: e.message });
+        }
+      } finally {
+        if (!aborted) setLoading(false);
+      }
+    };
+    search();
+    return () => {
+      aborted = true;
+    };
+  }, [filters, page]);
+
+  return { motos, loading, error, pageSize: PAGE_SIZE };
+}

--- a/src/lib/urlState.ts
+++ b/src/lib/urlState.ts
@@ -1,0 +1,20 @@
+import { Filters } from '@/types/filters';
+
+export function encodeState(filters: Filters, page: number): string {
+  const payload = JSON.stringify({ filters, page });
+  return Buffer.from(payload).toString('base64url');
+}
+
+export function decodeState(param: string | null): { filters: Filters; page: number } | null {
+  if (!param) return null;
+  try {
+    const json = Buffer.from(param, 'base64url').toString();
+    const parsed = JSON.parse(json);
+    return {
+      filters: parsed.filters || {},
+      page: typeof parsed.page === 'number' ? parsed.page : 0,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/types/filters.ts
+++ b/src/types/filters.ts
@@ -1,0 +1,32 @@
+export type Range = { min?: number; max?: number };
+
+export type Filters = {
+  price?: Range;
+  year?: Range;
+  brand_ids?: string[];
+  specs?: Record<string, boolean | string | string[] | Range | { in: string[] }>;
+};
+
+export interface FacetDistribution<T = string | boolean> {
+  value: T;
+  count: number;
+}
+
+export interface FacetItem {
+  key: string;
+  label: string;
+  unit?: string;
+  type: 'number' | 'boolean' | 'text' | 'enum';
+  min?: number;
+  max?: number;
+  dist_bool?: FacetDistribution<boolean>[];
+  dist_text?: FacetDistribution<string>[];
+  item_sort?: number;
+}
+
+export interface FacetGroup {
+  key: string;
+  label: string;
+  items: FacetItem[];
+  group_sort?: number;
+}


### PR DESCRIPTION
## Summary
- add hooks for fetching facets and moto search
- implement dynamic filters panel and URL state
- build moto listing page with immediate search and filter badges

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm run typecheck` *(fails: Cannot find module and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b4fee2c640832b819c012bc80fb0d9