### PR TITLE
feat: dynamic moto search with diagnostic tools

### DIFF
--- a/src/app/motos/page.tsx
+++ b/src/app/motos/page.tsx
@@ -4,8 +4,7 @@ import { useEffect, useState } from 'react'
 import MotoCard from '@/components/MotoCard'
 import FiltersPanel from '@/components/FiltersPanel'
 import { useMotoFacets } from '@/hooks/useMotoFacets'
-import { useMotoSearch } from '@/hooks/useMotoSearch'
-import type { Filters } from '@/types/filters'
+import { useMotoSearch, Filters, Range, cleanFilters } from '@/hooks/useMotoSearch'
 import {
   Pagination,
   PaginationContent,
@@ -14,118 +13,310 @@ import {
   PaginationPrevious,
   PaginationLink,
 } from '@/components/ui/pagination'
-
-function encodeFilters(filters: Filters) {
-  try {
-    const json = JSON.stringify(filters)
-    const base64 =
-      typeof window === 'undefined'
-        ? Buffer.from(json).toString('base64')
-        : window.btoa(json)
-    return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
-  } catch {
-    return ''
-  }
-}
-
-function decodeFilters(value: string): Filters {
-  try {
-    const base64 = value.replace(/-/g, '+').replace(/_/g, '/')
-    const pad = base64.length % 4 ? base64 + '='.repeat(4 - (base64.length % 4)) : base64
-    const json =
-      typeof window === 'undefined'
-        ? Buffer.from(pad, 'base64').toString()
-        : window.atob(pad)
-    return JSON.parse(json)
-  } catch {
-    return {}
-  }
-}
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet'
+import { Skeleton } from '@/components/ui/skeleton'
+import { encode, decode } from '@/utils/base64url'
 
 export default function MotosPage() {
-  const { facets } = useMotoFacets()
-  const [filters, setFilters] = useState<Filters>({ specs: {} })
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  const [filters, setFilters] = useState<Filters>({})
   const [page, setPage] = useState(0)
+  const { facets } = useMotoFacets()
+  const { motos, loading, error, lastRequest, lastResponse } = useMotoSearch(
+    filters,
+    page
+  )
+  const [diagOpen, setDiagOpen] = useState(false)
+  const [testResult, setTestResult] = useState<any>(null)
 
   // hydrate from URL
   useEffect(() => {
     const params = new URLSearchParams(window.location.search)
     const f = params.get('f')
     if (f) {
-      const parsed = decodeFilters(f)
-      setFilters({ specs: {}, ...parsed })
+      const decoded = decode<{ filters: Filters; page: number }>(f)
+      if (decoded.filters) setFilters(decoded.filters)
+      if (typeof decoded.page === 'number') setPage(decoded.page)
     }
-    const p = params.get('p')
-    if (p) setPage(parseInt(p, 10) || 0)
   }, [])
 
   // update URL when filters or page change
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search)
-    if (filters && Object.keys(filters).length > 0) {
-      params.set('f', encodeFilters(filters))
-    } else {
-      params.delete('f')
-    }
-    if (page > 0) {
-      params.set('p', String(page))
-    } else {
-      params.delete('p')
-    }
-    const url = `${window.location.pathname}?${params.toString()}`
+    const encoded = encode({ filters, page })
+    const url = `${window.location.pathname}?f=${encoded}`
     window.history.replaceState(null, '', url)
   }, [filters, page])
 
-  const { motos, loading } = useMotoSearch(filters, page)
+  const handleFilterChange = (next: Filters) => {
+    setFilters(next)
+    setPage(0)
+  }
+
+  function findItem(key: string) {
+    for (const g of facets) {
+      const it = g.items.find(i => i.key === key)
+      if (it) return it
+    }
+    return undefined
+  }
+
+  const badges: {
+    key: string
+    label: string
+    value: string
+    remove: () => void
+  }[] = []
+  const cleaned = cleanFilters(filters)
+  if (cleaned.price) {
+    const item = findItem('price')
+    badges.push({
+      key: 'price',
+      label: item?.label || 'price',
+      value: `${cleaned.price.min ?? ''}-${cleaned.price.max ?? ''}`,
+      remove: () => setFilters(f => ({ ...f, price: undefined })),
+    })
+  }
+  if (cleaned.year) {
+    const item = findItem('year')
+    badges.push({
+      key: 'year',
+      label: item?.label || 'year',
+      value: `${cleaned.year.min ?? ''}-${cleaned.year.max ?? ''}`,
+      remove: () => setFilters(f => ({ ...f, year: undefined })),
+    })
+  }
+  if (cleaned.brand_ids) {
+    const item = findItem('brand_ids')
+    cleaned.brand_ids.forEach(id => {
+      badges.push({
+        key: `brand_ids:${id}`,
+        label: item?.label || 'brand_ids',
+        value: id,
+        remove: () =>
+          setFilters(f => ({
+            ...f,
+            brand_ids: f.brand_ids?.filter(b => b !== id),
+          })),
+      })
+    })
+  }
+  if (cleaned.specs) {
+    for (const [k, v] of Object.entries(cleaned.specs)) {
+      const item = findItem(k)
+      if (typeof v === 'boolean') {
+        badges.push({
+          key: k,
+          label: item?.label || k,
+          value: v ? 'Oui' : 'Non',
+          remove: () =>
+            setFilters(f => {
+              const n = { ...f }
+              if (n.specs) {
+                delete n.specs[k]
+                if (Object.keys(n.specs).length === 0) delete n.specs
+              }
+              return n
+            }),
+        })
+      } else if (Array.isArray(v)) {
+        v.forEach(val =>
+          badges.push({
+            key: `${k}:${val}`,
+            label: item?.label || k,
+            value: val,
+            remove: () =>
+              setFilters(f => {
+                const n = { ...f }
+                const arr = (n.specs?.[k] as string[]).filter(v2 => v2 !== val)
+                if (arr.length > 0) {
+                  n.specs = { ...n.specs, [k]: arr }
+                } else if (n.specs) {
+                  delete n.specs[k]
+                  if (Object.keys(n.specs).length === 0) delete n.specs
+                }
+                return n
+              }),
+          })
+        )
+      } else if (typeof v === 'object' && v) {
+        if ('in' in v) {
+          v.in.forEach(val =>
+            badges.push({
+              key: `${k}:${val}`,
+              label: item?.label || k,
+              value: val,
+              remove: () =>
+                setFilters(f => {
+                  const n = { ...f }
+                  const arr = (n.specs?.[k] as any).in.filter(
+                    (x: string) => x !== val
+                  )
+                  if (arr.length > 0) {
+                    n.specs = { ...n.specs, [k]: { in: arr } }
+                  } else if (n.specs) {
+                    delete n.specs[k]
+                    if (Object.keys(n.specs).length === 0) delete n.specs
+                  }
+                  return n
+                }),
+            })
+          )
+        } else {
+          badges.push({
+            key: k,
+            label: item?.label || k,
+            value: `${(v as Range).min ?? ''}-${(v as Range).max ?? ''}`,
+            remove: () =>
+              setFilters(f => {
+                const n = { ...f }
+                if (n.specs) {
+                  delete n.specs[k]
+                  if (Object.keys(n.specs).length === 0) delete n.specs
+                }
+                return n
+              }),
+          })
+        }
+      }
+    }
+  }
+
+  async function runTest() {
+    if (!supabaseUrl || !supabaseAnon) return
+    const res = await fetch(`${supabaseUrl}/rest/v1/rpc/fn_search_motos`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: supabaseAnon,
+        Authorization: `Bearer ${supabaseAnon}`,
+      },
+      body: JSON.stringify({ p_filters: {}, p_limit: 1, p_offset: 0 }),
+    })
+    const data = await res.json().catch(() => null)
+    setTestResult(data)
+  }
 
   return (
-    <div className="flex gap-6 p-6">
-      <aside className="w-64 hidden md:block">
-        <FiltersPanel
-          facets={facets}
-          filters={filters}
-          onChange={fn => {
-            setFilters(prev => fn(prev))
-            setPage(0)
-          }}
-        />
-      </aside>
-      <div className="flex-1">
-        <div className="mb-4 flex items-center justify-between">
-          <div className="font-semibold">{motos.length} résultats</div>
+    <div className="p-4 space-y-4">
+      {!supabaseUrl || !supabaseAnon ? (
+        <div className="bg-red-500 text-white p-2 text-center">
+          Config manquante : NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY — configurez .env.local
         </div>
-        <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
-          {motos.map(m => (
-            <MotoCard key={m.id} moto={m} />
-          ))}
+      ) : null}
+      <div className="md:hidden">
+        <Sheet>
+          <SheetTrigger asChild>
+            <Button variant="outline">Filtres</Button>
+          </SheetTrigger>
+          <SheetContent side="left" className="overflow-y-auto p-4">
+            <FiltersPanel
+              facets={facets}
+              filters={filters}
+              onChange={handleFilterChange}
+            />
+          </SheetContent>
+        </Sheet>
+      </div>
+      <div className="flex gap-6">
+        <aside className="w-64 hidden md:block">
+          <FiltersPanel
+            facets={facets}
+            filters={filters}
+            onChange={handleFilterChange}
+          />
+        </aside>
+        <div className="flex-1">
+          <div className="mb-4 flex flex-wrap gap-2">
+            {badges.map(b => (
+              <Badge key={b.key} onClick={b.remove} className="cursor-pointer">
+                {b.label}: {b.value}
+              </Badge>
+            ))}
+          </div>
+          {loading ? (
+            <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <Skeleton key={i} className="h-48" />
+              ))}
+            </div>
+          ) : motos.length === 0 ? (
+            <div>Aucun résultat</div>
+          ) : (
+            <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+              {motos.map(m => (
+                <MotoCard key={m.id} moto={m} />
+              ))}
+            </div>
+          )}
+          <Pagination className="mt-6">
+            <PaginationContent>
+              <PaginationItem>
+                <PaginationPrevious
+                  href="#"
+                  onClick={e => {
+                    e.preventDefault()
+                    if (page > 0) setPage(page - 1)
+                  }}
+                />
+              </PaginationItem>
+              <PaginationItem>
+                <PaginationLink href="#" isActive>
+                  {page + 1}
+                </PaginationLink>
+              </PaginationItem>
+              <PaginationItem>
+                <PaginationNext
+                  href="#"
+                  onClick={e => {
+                    e.preventDefault()
+                    setPage(page + 1)
+                  }}
+                />
+              </PaginationItem>
+            </PaginationContent>
+          </Pagination>
+          <div className="mt-4">
+            <Button variant="ghost" onClick={() => setDiagOpen(o => !o)}>
+              Diagnostic
+            </Button>
+            {diagOpen && (
+              <div className="mt-2 border p-4 space-y-2 text-sm">
+                <div>Environnement</div>
+                <pre className="overflow-x-auto">
+                  {JSON.stringify(
+                    {
+                      NEXT_PUBLIC_SUPABASE_URL: supabaseUrl,
+                      NEXT_PUBLIC_SUPABASE_ANON_KEY: supabaseAnon
+                        ? supabaseAnon.replace(/.(?=.{4})/g, '*')
+                        : null,
+                    },
+                    null,
+                    2
+                  )}
+                </pre>
+                <div>lastRequest</div>
+                <pre className="overflow-x-auto">
+                  {JSON.stringify(lastRequest, null, 2)}
+                </pre>
+                <div>lastResponse</div>
+                <pre className="overflow-x-auto">
+                  {JSON.stringify(lastResponse, null, 2)}
+                </pre>
+                <Button size="sm" onClick={runTest}>
+                  Test direct
+                </Button>
+                {testResult && (
+                  <pre className="overflow-x-auto">
+                    {JSON.stringify(testResult, null, 2)}
+                  </pre>
+                )}
+              </div>
+            )}
+          </div>
         </div>
-        <Pagination className="mt-6">
-          <PaginationContent>
-            <PaginationItem>
-              <PaginationPrevious
-                href="#"
-                onClick={e => {
-                  e.preventDefault()
-                  if (page > 0) setPage(page - 1)
-                }}
-              />
-            </PaginationItem>
-            <PaginationItem>
-              <PaginationLink href="#" isActive>
-                {page + 1}
-              </PaginationLink>
-            </PaginationItem>
-            <PaginationItem>
-              <PaginationNext
-                href="#"
-                onClick={e => {
-                  e.preventDefault()
-                  setPage(page + 1)
-                }}
-              />
-            </PaginationItem>
-          </PaginationContent>
-        </Pagination>
       </div>
     </div>
   )

--- a/src/hooks/useMotoFacets.ts
+++ b/src/hooks/useMotoFacets.ts
@@ -20,8 +20,8 @@ export function useMotoFacets() {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            apikey: anon,
-            Authorization: `Bearer ${anon}`,
+            apikey: anon!,
+            Authorization: `Bearer ${anon!}`,
           },
           body: JSON.stringify({}),
           signal: controller.signal,

--- a/src/hooks/useMotoFacets.ts
+++ b/src/hooks/useMotoFacets.ts
@@ -3,52 +3,55 @@
 import { useEffect, useState } from 'react'
 import type { FacetGroup } from '@/types/filters'
 
-const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const SUPABASE_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-
 export function useMotoFacets() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
   const [facets, setFacets] = useState<FacetGroup[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<Error | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    const fetchFacets = async () => {
+    if (!url || !anon) return
+    const controller = new AbortController()
+    async function run() {
       try {
-        const res = await fetch(
-          `${SUPABASE_URL}/rest/v1/rpc/fn_get_filter_facets`,
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              apikey: SUPABASE_KEY,
-              Authorization: `Bearer ${SUPABASE_KEY}`,
-            },
-            body: JSON.stringify({}),
-          }
+        setLoading(true)
+        const res = await fetch(`${url}/rest/v1/rpc/fn_get_filter_facets`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            apikey: anon,
+            Authorization: `Bearer ${anon}`,
+          },
+          body: JSON.stringify({}),
+          signal: controller.signal,
+        })
+        const data: FacetGroup[] = await res.json().catch(() => [])
+        data.sort(
+          (a, b) =>
+            (a.group_sort ?? Infinity) - (b.group_sort ?? Infinity) ||
+            a.group.localeCompare(b.group)
         )
-        if (!res.ok) {
-          throw new Error(`Failed to load facets: ${res.status}`)
-        }
-        const data: FacetGroup[] = await res.json()
-        // sort groups and items
-        data.sort((a, b) => (a.group_sort ?? 0) - (b.group_sort ?? 0))
         data.forEach(g =>
           g.items.sort(
             (a, b) =>
-              (a.item_sort ?? 0) - (b.item_sort ?? 0) ||
-              (a.label?.localeCompare(b.label ?? '') ?? 0)
+              (a.item_sort ?? Infinity) - (b.item_sort ?? Infinity) ||
+              (a.label ?? a.key).localeCompare(b.label ?? b.key)
           )
         )
         setFacets(data)
-      } catch (err) {
-        setError(err as Error)
+        setError(null)
+      } catch (err: any) {
+        if (err.name !== 'AbortError') {
+          setError(err.message ?? String(err))
+        }
       } finally {
         setLoading(false)
       }
     }
-
-    fetchFacets()
-  }, [])
+    run()
+    return () => controller.abort()
+  }, [url, anon])
 
   return { facets, loading, error }
 }

--- a/src/hooks/useMotoSearch.ts
+++ b/src/hooks/useMotoSearch.ts
@@ -73,8 +73,8 @@ export function useMotoSearch(filters: Filters, page: number) {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            apikey: anon,
-            Authorization: `Bearer ${anon}`,
+            apikey: anon!,
+            Authorization: `Bearer ${anon!}`,
           },
           body: JSON.stringify(body),
           signal: controller.signal,

--- a/src/hooks/useMotoSearch.ts
+++ b/src/hooks/useMotoSearch.ts
@@ -1,82 +1,112 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import type { Filters } from '@/types/filters'
 
-const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const SUPABASE_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-
-export interface MotoSearchResult {
-  id: string
-  brand: string
-  model: string
-  year?: number | null
-  price?: number | null
-  display_image?: string | null
+export type Range = { min?: number; max?: number }
+export type Filters = {
+  price?: Range
+  year?: Range
+  brand_ids?: string[]
+  specs?: Record<string, boolean | string | string[] | Range | { in: string[] }>
 }
 
-function useDebouncedValue<T>(value: T, delay: number) {
-  const [debounced, setDebounced] = useState(value)
-
-  useEffect(() => {
-    const handler = setTimeout(() => setDebounced(value), delay)
-    return () => clearTimeout(handler)
-  }, [value, delay])
-
-  return debounced
+export function cleanFilters(input: Filters): Filters {
+  const output: Filters = {}
+  if (input.price && (input.price.min !== undefined || input.price.max !== undefined)) {
+    output.price = { ...input.price }
+  }
+  if (input.year && (input.year.min !== undefined || input.year.max !== undefined)) {
+    output.year = { ...input.year }
+  }
+  if (input.brand_ids && input.brand_ids.length > 0) {
+    output.brand_ids = [...input.brand_ids]
+  }
+  if (input.specs) {
+    const specs: Filters['specs'] = {}
+    for (const [key, value] of Object.entries(input.specs)) {
+      if (value === undefined || value === null) continue
+      if (typeof value === 'string') {
+        if (value !== '') specs[key] = value
+      } else if (typeof value === 'boolean') {
+        specs[key] = value
+      } else if (Array.isArray(value)) {
+        if (value.length > 0) specs[key] = value
+      } else if ('in' in value) {
+        if (Array.isArray(value.in) && value.in.length > 0) specs[key] = { in: [...value.in] }
+      } else {
+        const range = value as Range
+        if (range.min !== undefined || range.max !== undefined) {
+          specs[key] = { ...range }
+        }
+      }
+    }
+    if (specs && Object.keys(specs).length > 0) {
+      output.specs = specs
+    }
+  }
+  return output
 }
 
 export function useMotoSearch(filters: Filters, page: number) {
-  const [motos, setMotos] = useState<MotoSearchResult[]>([])
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  const [motos, setMotos] = useState<any[]>([])
   const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<Error | null>(null)
-
-  const debouncedFilters = useDebouncedValue(filters, 300)
-  const debouncedPage = useDebouncedValue(page, 300)
+  const [error, setError] = useState<string | null>(null)
+  const [lastRequest, setLastRequest] = useState<any>(null)
+  const [lastResponse, setLastResponse] = useState<any>(null)
 
   useEffect(() => {
+    if (!url || !anon) return
     const controller = new AbortController()
-
     async function run() {
+      const body = {
+        p_filters: cleanFilters(filters),
+        p_limit: 24,
+        p_offset: page * 24,
+      }
       try {
+        console.debug('[filters->RPC]', body.p_filters)
         setLoading(true)
-        const res = await fetch(`${SUPABASE_URL}/rest/v1/rpc/fn_search_motos`, {
+        setLastRequest(body)
+        const res = await fetch(`${url}/rest/v1/rpc/fn_search_motos`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            apikey: SUPABASE_KEY,
-            Authorization: `Bearer ${SUPABASE_KEY}`,
+            apikey: anon,
+            Authorization: `Bearer ${anon}`,
           },
-          body: JSON.stringify({
-            p_filters: debouncedFilters,
-            p_limit: 24,
-            p_offset: debouncedPage * 24,
-          }),
+          body: JSON.stringify(body),
           signal: controller.signal,
         })
-        if (!res.ok) {
-          throw new Error(`Search failed: ${res.status}`)
+        const rows = await res.json().catch(() => [])
+        setLastResponse(rows)
+        console.debug('[RPC->rows]', rows)
+        let list: any[] = []
+        if (Array.isArray(rows)) {
+          if (rows.every(r => r && typeof r === 'object' && 'j' in r)) {
+            list = rows.map((r: any) => r.j)
+          } else if (rows.every(r => typeof r === 'object')) {
+            list = rows as any[]
+          }
+        } else if (rows && typeof rows === 'object') {
+          list = [rows]
         }
-        const data: MotoSearchResult[] = await res.json()
-        setMotos(data)
+        setMotos(list)
         setError(null)
       } catch (err: any) {
         if (err.name !== 'AbortError') {
-          setError(err as Error)
+          setError(err.message ?? String(err))
         }
       } finally {
         setLoading(false)
       }
     }
-
     run()
+    return () => controller.abort()
+  }, [filters, page, url, anon])
 
-    return () => {
-      controller.abort()
-    }
-  }, [debouncedFilters, debouncedPage])
-
-  return { motos, loading, error }
+  return { motos, loading, error, lastRequest, lastResponse }
 }
 
 export default useMotoSearch

--- a/src/utils/base64url.ts
+++ b/src/utils/base64url.ts
@@ -1,0 +1,26 @@
+export function encode(data: any): string {
+  try {
+    const json = typeof data === 'string' ? data : JSON.stringify(data);
+    const base64 = typeof window === 'undefined'
+      ? Buffer.from(json).toString('base64')
+      : window.btoa(json);
+    return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  } catch {
+    return '';
+  }
+}
+
+export function decode<T = any>(value: string): T {
+  try {
+    const base64 = value.replace(/-/g, '+').replace(/_/g, '/');
+    const pad = base64.length % 4
+      ? base64 + '='.repeat(4 - (base64.length % 4))
+      : base64;
+    const json = typeof window === 'undefined'
+      ? Buffer.from(pad, 'base64').toString()
+      : window.atob(pad);
+    return JSON.parse(json) as T;
+  } catch {
+    return {} as T;
+  }
+}


### PR DESCRIPTION
## Summary
- trigger `fn_search_motos` on every filter change with payload cleanup and request/response diagnostics
- load and sort filter facets dynamically from Supabase
- revamp filter panel with range inputs, tri-state booleans, and reset plus active filter badges
- add diagnostic panel, env checks, and base64url state sync for the motos page

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: 403 Forbidden from registry)*
- `npm run typecheck` *(fails: missing modules and types)*

------
https://chatgpt.com/codex/tasks/task_e_68b507aa6658832bbdbbed5d52b65a9d