### PR TITLE
Refactor moto filters to use URL query parameters

### DIFF
--- a/src/components/CompareFilters.tsx
+++ b/src/components/CompareFilters.tsx
@@ -5,18 +5,18 @@ import { supabase } from "@/lib/supabaseClient";
 type Option = { value: string; label: string };
 
 export default function CompareFilters(props: {
-  onBrandChange?: (brandId: string | null) => void;
+  onBrandChange?: (brand_id: string | null) => void;
   onModelChange?: (model: string | null) => void;
-  defaultBrandId?: string | null;
-  defaultModel?: string | null;
+  default_brand_id?: string | null;
+  default_model?: string | null;
 }) {
   const [brands, setBrands] = React.useState<Option[]>([]);
   const [models, setModels] = React.useState<Option[]>([]);
-  const [brandId, setBrandId] = React.useState<string | null>(
-    props.defaultBrandId ?? null,
+  const [brand_id, setBrandId] = React.useState<string | null>(
+    props.default_brand_id ?? null,
   );
   const [model, setModel] = React.useState<string | null>(
-    props.defaultModel ?? null,
+    props.default_model ?? null,
   );
   const [loadingBrands, setLoadingBrands] = React.useState(false);
   const [loadingModels, setLoadingModels] = React.useState(false);
@@ -47,7 +47,7 @@ export default function CompareFilters(props: {
 
   React.useEffect(() => {
     const loadModels = async () => {
-      if (!brandId) {
+      if (!brand_id) {
         setModels([]);
         setModel(null);
         return;
@@ -58,7 +58,7 @@ export default function CompareFilters(props: {
         let { data, error } = await supabase
           .from("models")
           .select("name")
-          .eq("brand_id", brandId)
+          .eq("brand_id", brand_id)
           .order("name", { ascending: true });
 
         if (error || !data?.length) {
@@ -67,7 +67,7 @@ export default function CompareFilters(props: {
             // Cast options to any to accommodate "distinct", which is supported
             // by Supabase but missing from the current type definitions.
             .select("model_name", { distinct: true } as any)
-            .eq("brand_id", brandId)
+            .eq("brand_id", brand_id)
             .order("model_name", { ascending: true });
           if (err) throw err;
           setModels(
@@ -91,7 +91,7 @@ export default function CompareFilters(props: {
       }
     };
     loadModels();
-  }, [brandId]);
+  }, [brand_id]);
 
   return (
     <div className="grid gap-4 md:grid-cols-2">
@@ -99,7 +99,7 @@ export default function CompareFilters(props: {
         <label className="block text-sm mb-2">Marque</label>
         <select
           className="w-full border rounded p-2"
-          value={brandId ?? ""}
+          value={brand_id ?? ""}
           onChange={(e) => {
             const v = e.target.value || null;
             setBrandId(v);
@@ -122,7 +122,7 @@ export default function CompareFilters(props: {
         <select
           className="w-full border rounded p-2"
           value={model ?? ""}
-          disabled={!brandId}
+          disabled={!brand_id}
           onChange={(e) => {
             const v = e.target.value || null;
             setModel(v);
@@ -130,7 +130,7 @@ export default function CompareFilters(props: {
           }}
         >
           <option value="">
-            {!brandId
+            {!brand_id
               ? "Choisir d’abord une marque"
               : loadingModels
                 ? "Chargement…"

--- a/src/components/motos/Filters.tsx
+++ b/src/components/motos/Filters.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { useRouter, useSearchParams } from 'next/navigation'
+import { startTransition } from 'react'
+
+interface BrandOption {
+  id: string
+  name: string
+}
+
+interface FiltersProps {
+  brands: BrandOption[]
+}
+
+export default function Filters({ brands }: FiltersProps) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const handleChange = (key: string, value: string) => {
+    const qs = new URLSearchParams(searchParams.toString())
+    if (value) qs.set(key, value)
+    else qs.delete(key)
+    const query = qs.toString()
+    startTransition(() => {
+      router.replace(query ? `/motos?${query}` : '/motos', { scroll: false })
+    })
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <select
+        value={searchParams.get('brand_id') ?? ''}
+        onChange={e => handleChange('brand_id', e.target.value)}
+        className="border p-2 rounded"
+      >
+        <option value="">Toutes marques</option>
+        {brands.map(b => (
+          <option key={b.id} value={b.id}>
+            {b.name}
+          </option>
+        ))}
+      </select>
+      <div className="flex gap-2">
+        <input
+          type="number"
+          placeholder="Année min"
+          value={searchParams.get('year_min') ?? ''}
+          onChange={e => handleChange('year_min', e.target.value)}
+          className="border p-2 rounded w-full"
+        />
+        <input
+          type="number"
+          placeholder="Année max"
+          value={searchParams.get('year_max') ?? ''}
+          onChange={e => handleChange('year_max', e.target.value)}
+          className="border p-2 rounded w-full"
+        />
+      </div>
+      <div className="flex gap-2">
+        <input
+          type="number"
+          step="0.01"
+          placeholder="Prix min"
+          value={searchParams.get('price_min') ?? ''}
+          onChange={e => handleChange('price_min', e.target.value)}
+          className="border p-2 rounded w-full"
+        />
+        <input
+          type="number"
+          step="0.01"
+          placeholder="Prix max"
+          value={searchParams.get('price_max') ?? ''}
+          onChange={e => handleChange('price_max', e.target.value)}
+          className="border p-2 rounded w-full"
+        />
+      </div>
+      <input
+        type="text"
+        placeholder="Recherche"
+        value={searchParams.get('q') ?? ''}
+        onChange={e => handleChange('q', e.target.value)}
+        className="border p-2 rounded"
+      />
+    </div>
+  )
+}
+

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,7 +10,7 @@ export interface Brand {
 export interface Model {
   id: string;
   name: string;
-  brandId: string;
+  brand_id: string;
   category: string;
   image: string;
   description?: string;
@@ -46,7 +46,7 @@ export interface Features {
 
 export interface Version {
   id: string;
-  modelId: string;
+  model_id: string;
   name: string;
   price: number;
   engine: EngineSpecs;


### PR DESCRIPTION
## Summary
- replace client-side moto listing with server component that parses canonical query params and builds Supabase query
- add URL-driven Filters component to keep controls in sync with search params
- rename legacy brandId/modelId usages to brand_id/model_id

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b51357f930832bb60e3e0927fe383c