### PR TITLE
fix: allow partial moto data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .env
 .env.*
 !.env.example
+tsconfig.tsbuildinfo

--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -2,26 +2,15 @@
 import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import { createClient } from "@supabase/supabase-js";
-// ✅ Correct relative path from src/app/HomeClient.tsx to src/components/MotoCard.tsx
-import MotoCardView from "../components/MotoCard";
-
-type MotoRow = {
-  id: string;
-  brand_name: string;
-  model_name: string;
-  year: number | null;
-  price_tnd: number | null;
-};
-
-// Re-expose as `MotoCard` locally so existing JSX `<MotoCard .../>` works
-const MotoCard = (props: { moto: MotoRow }) => <MotoCardView {...props} />;
+import MotoCard from "@/components/MotoCard";
+import type { MotoCard as MotoCardType } from "@/lib/public/motos";
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
 const supabase = createClient(supabaseUrl, supabaseAnonKey);
 
 export default function HomeClient() {
-  const [motos, setMotos] = useState<MotoRow[]>([]);
+  const [motos, setMotos] = useState<MotoCardType[]>([]);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
 
@@ -36,7 +25,7 @@ export default function HomeClient() {
           .select("id,brand_name,model_name,year,price_tnd")
           .limit(12);
         if (error) throw error;
-        if (!cancelled) setMotos((data ?? []) as MotoRow[]);
+        if (!cancelled) setMotos((data ?? []) as MotoCardType[]);
       } catch (e: any) {
         if (!cancelled) setErr(e.message || "Erreur inconnue");
       } finally {
@@ -45,7 +34,7 @@ export default function HomeClient() {
     }
     run();
     return () => {
-      cancelled = true; // ✅ bugfix
+      cancelled = true;
     };
   }, []);
 

--- a/src/app/marques/[brandSlug]/page.tsx
+++ b/src/app/marques/[brandSlug]/page.tsx
@@ -14,11 +14,15 @@ export function generateMetadata(): Metadata {
 export default async function BrandPage({ params }: PageProps) {
   const motos = await getPublishedMotos();
   const brand = params.brandSlug.toLowerCase();
-  const filtered = motos.filter((m) => (m.brand || '').toLowerCase() === brand);
+  const filtered = motos.filter(
+    (m) => (m.brand_name || '').toLowerCase() === brand
+  );
   if (filtered.length === 0) return notFound();
   return (
     <main className="mx-auto max-w-6xl px-4 py-8">
-      <h1 className="text-3xl font-semibold mb-4">{filtered[0].brand}</h1>
+      <h1 className="text-3xl font-semibold mb-4">
+        {filtered[0].brand_name ?? ''}
+      </h1>
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {filtered.map((m) => (
           <MotoCard key={m.id} moto={m} />

--- a/src/app/marques/page.tsx
+++ b/src/app/marques/page.tsx
@@ -17,7 +17,7 @@ export default async function MarquesPage() {
   const motos = await getPublishedMotos();
   const brandMap: Record<string, number> = {};
   motos.forEach((m) => {
-    const b = m.brand || 'Autres';
+    const b = m.brand_name || 'Autres';
     brandMap[b] = (brandMap[b] || 0) + 1;
   });
   const brands: BrandInfo[] = Object.entries(brandMap)

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,6 @@
 import HomeClient from "./HomeClient";
-import { getPublishedMotos } from "@/lib/public/motos";
 
-export default async function Home() {
-  const motos = await getPublishedMotos();
-  const featured =
-    motos.length >= 6
-      ? [...motos].sort(() => 0.5 - Math.random()).slice(0, 6)
-      : motos;
-  return <HomeClient featured={featured} />;
+export default function Home() {
+  return <HomeClient />;
 }
 

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -22,7 +22,7 @@ export default function CompareTable({ motos }: CompareTableProps) {
             <th className="p-2 text-left">Spécifications</th>
             {motos.map((m) => (
               <th key={m.slug ?? m.id} className="p-2 text-left">
-                {m.model}
+                {`${m.brand_name ?? ''} ${m.model_name ?? ''}`.trim()}
               </th>
             ))}
           </tr>
@@ -40,7 +40,7 @@ export default function CompareTable({ motos }: CompareTableProps) {
             <th className="p-2 text-left font-medium">Prix (TND)</th>
             {motos.map((m) => (
               <td key={(m.slug ?? m.id) + '_price'} className="p-2">
-                {fmtPrice(m.price)}
+                {fmtPrice(m.price_tnd)}
               </td>
             ))}
           </tr>

--- a/src/components/MotoCard.tsx
+++ b/src/components/MotoCard.tsx
@@ -1,20 +1,20 @@
 "use client";
 import Link from "next/link";
+import type { MotoCard as MotoCardType } from "@/lib/public/motos";
 
-export default function MotoCard({ moto }: { moto: {
-  id: string;
-  brand_name: string;
-  model_name: string;
-  year: number | null;
-  price_tnd: number | null;
-}}) {
+export default function MotoCard({ moto }: { moto: MotoCardType }) {
   const img = `/images/motos/${moto.id}.webp`;
+  const brand = moto.brand_name ?? "";
+  const model = moto.model_name ?? "";
   return (
-    <Link href={`/motos/${moto.id}`} className="block border rounded overflow-hidden hover:shadow-sm bg-white">
+    <Link
+      href={`/motos/${moto.id}`}
+      className="block border rounded overflow-hidden hover:shadow-sm bg-white"
+    >
       <div className="aspect-[4/3] bg-gray-100">
         <img
           src={img}
-          alt={`${moto.brand_name} ${moto.model_name}`}
+          alt={`${brand} ${model}`.trim()}
           className="w-full h-full object-cover"
           onError={(e) => {
             (e.target as HTMLImageElement).src = "/images/placeholder.webp";
@@ -23,9 +23,13 @@ export default function MotoCard({ moto }: { moto: {
         />
       </div>
       <div className="p-3">
-        <div className="text-sm text-gray-500">{moto.brand_name}</div>
-        <div className="font-medium">{moto.model_name} {moto.year ? `(${moto.year})` : ""}</div>
-        <div className="text-sm text-gray-700 mt-1">{moto.price_tnd != null ? `${moto.price_tnd} TND` : "—"}</div>
+        <div className="text-sm text-gray-500">{brand}</div>
+        <div className="font-medium">
+          {model} {moto.year ? `(${moto.year})` : ""}
+        </div>
+        <div className="text-sm text-gray-700 mt-1">
+          {moto.price_tnd != null ? `${moto.price_tnd} TND` : "—"}
+        </div>
       </div>
     </Link>
   );

--- a/src/lib/public/motos.ts
+++ b/src/lib/public/motos.ts
@@ -11,16 +11,24 @@ function supabaseServer() {
 }
 
 export type MotoCard = {
-  id: string; brand: string|null; model: string|null; year: number|null; price: number|null;
-  slug: string|null; display_image: string|null;
+  id: string;
+  brand_name: string | null;
+  model_name: string | null;
+  year: number | null;
+  price_tnd: number | null;
+  slug?: string | null;
+  display_image?: string | null;
 };
 
 export async function getPublishedMotos(): Promise<MotoCard[]> {
   const s = supabaseServer();
-  const { data } = await s.from('motos_public')
-    .select('id,brand,model,year,price,slug,display_image')
+  const { data } = await s
+    .from('motos_public')
+    .select(
+      'id,brand_name:brand,model_name:model,year,price_tnd:price,slug,display_image'
+    )
     .order('id', { ascending: false });
-  return data ?? [];
+  return (data ?? []) as MotoCard[];
 }
 
 export type MotoSpec = {


### PR DESCRIPTION
## Summary
- make `slug` and `display_image` optional in `MotoCard` type
- reuse `MotoCard` type in home client to avoid missing fields

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm run typecheck` *(fails: Cannot find module '@supabase/ssr' or type declarations)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b847511274832bae7fa081cd4efe25